### PR TITLE
[WIP] Emit tail calls to __mspabi_func_epilog_X

### DIFF
--- a/llvm/lib/Target/MSP430/MSP430FrameLowering.h
+++ b/llvm/lib/Target/MSP430/MSP430FrameLowering.h
@@ -38,6 +38,7 @@ public:
                                  MachineBasicBlock::iterator MI,
                                  ArrayRef<CalleeSavedInfo> CSI,
                                  const TargetRegisterInfo *TRI) const override;
+  const char *tailCallNameForRestoringCalleSavedRegisters(MutableArrayRef<CalleeSavedInfo> CSI) const;
   bool
   restoreCalleeSavedRegisters(MachineBasicBlock &MBB,
                               MachineBasicBlock::iterator MI,

--- a/llvm/test/CodeGen/MSP430/epilog-spilled-restore.ll
+++ b/llvm/test/CodeGen/MSP430/epilog-spilled-restore.ll
@@ -1,0 +1,14 @@
+; RUN: llc < %s | FileCheck %s
+
+target datalayout = "e-m:e-p:16:16-i32:16-i64:16-f32:16-f64:16-a:8-n8:16-S16"
+target triple = "msp430"
+
+; TODO check other counts
+; TODO check 7 regs! (something strange happens...)
+
+define void @pops_4_regs() nounwind {
+; CHECK-LABEL: pops_4_regs
+  call void asm sideeffect "", "~{r7},~{r8},~{r9},~{r10}"()
+  ret void
+; CHECK: jmp __mspabi_func_epilog_4
+}


### PR DESCRIPTION
Here is a draft PR for internal discussion of a fix for #1. For now, it is expected to be squashed/rebased periodically, when appropriate for discussion.

To Do
- [x] create a stub patch that just compiles and tests itself somehow
- [ ] ensure the resulting code can be linked correctly (all symbols can be resolved, etc.)
- [ ] find out why `R4` seems to not being spilled just like `R5` - `R10` (or why this is correct). For now, this looks contradicting MSP EABI
- [ ] get rid of the dangling `ret` at the very end of a function
- [ ] rewrite string handling idiomatically (symbol names: use literal constant strings, dynamic formatting on stack / on heap, etc.; speed / allocation / maintainability trade-off)
- [ ] ultimately improve it to upstreamable quality