### PR TITLE
[WIP] [CodeGen] Validate clobber constraint for inline asm

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/FunctionLoweringInfo.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FunctionLoweringInfo.cpp
@@ -209,6 +209,15 @@ void FunctionLoweringInfo::set(const Function &fn, MachineFunction &mf,
               std::pair<unsigned, const TargetRegisterClass *> PhysReg =
                   TLI->getRegForInlineAsmConstraint(TRI, Op.ConstraintCode,
                                                     Op.ConstraintVT);
+              bool CanParseMachineRegisterOrMemory =
+                  PhysReg.first != 0 ||
+                  StringRef(Op.ConstraintCode).equals_lower("{memory}");
+              if (!CanParseMachineRegisterOrMemory) {
+                errs() << format("Invalid clobber constraint '%s' "
+                                 "was specified for inline asm\n",
+                                 Op.ConstraintCode.c_str());
+                llvm_unreachable("Cannot parse clobber constraint");
+              }
               if (PhysReg.first == SP)
                 MF->getFrameInfo().setHasOpaqueSPAdjustment(true);
             }


### PR DESCRIPTION
This is an early draft fix of #10 w.r.t. clobber constraints (they seem to be quite trivial according to the [LLVM IR reference](https://llvm.org/docs/LangRef.html#clobber-constraints)). This PR **does not** cover any other constraint kinds.

It **does not** pass regression tests now. While it may indicate plainly incorrect implementation of this PR (and most probably this is the case), sometimes it triggers on suspicious parts of code. For example, `CodeGen/X86/swifterror.ll` fails when run as

```
llc -verify-machineinstrs -mtriple=i386-apple-darwin -disable-block-placement < swifterror.ll
```

due to usage of

```ll
  call void asm sideeffect "nop", "~{r12}"()
```
for testing on `i386`. Whether this is an error or not, I don't know. Still, this looks slightly suspicious.

Please note this PR is most probably very broken right now and is mostly here for discussion on what to check and what to ignore (and hopefully to produce some correct validation someday).