### PR TITLE
[MSP430] Update toolchain description for msp430-gcc-8.3.1.25

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -1503,7 +1503,9 @@ static bool findMSP430Multilibs(const Driver &D,
                                 StringRef Path, const ArgList &Args,
                                 DetectedMultilibs &Result) {
   FilterNonExistent NonExistent(Path, "/crtbegin.o", D.getVFS());
-  Multilib MSP430Multilib = makeMultilib("/430");
+  Multilib MSP430Multilib = Args.hasArg(options::OPT_fexceptions) ?
+        makeMultilib("/430/exceptions") : makeMultilib("/430");
+
   // FIXME: when clang starts to support msp430x ISA additional logic
   // to select between multilib must be implemented
   // Multilib MSP430xMultilib = makeMultilib("/large");


### PR DESCRIPTION
This patch updates MSP430 toolchain description for current mspgcc package provided by TI. It does not try to be backward-compatible yet.

This patch expects the check for `options::OPT_fexceptions` to always return correct value based on `-fexceptions`, `-fno-exceptions` and the default value, that is probably not the case...

Actual object and archive file sequence is _based_ on "deciphered" output of `msp430-elf-gcc -dumpspecs` and `gcc/gcc/config/msp430/msp430.h` source file. Still, it lacks some parts such as stack-smashing protector that seems to be supported on MSP430 according to presence of `libssp.a`. Of course, it omits all the sanitizer runtimes.

Provided `uart-test.c` contains the UART example [from MSP430-Emulator documentation](http://www.msp430emulator.com/examples.html#2), both commands

```sh
/path/to/bin/clang -target msp430 --sysroot=/path/to/msp430gcc uart-test.c -v -mmcu=msp430g2553 -o uart-test
/path/to/bin/clang -target msp430 --sysroot=/path/to/msp430gcc uart-test.c -v -mmcu=msp430g2553 -o uart-test -fexceptions
```

produce executables that can be run on emulator by
* Uploading firmware
* `dump 0xfffe`
* `set pc 0x<value of reset vector>`
* `run`

Here, the `--sysroot` option points to TI's binary distribution:
```
$ cd /path/to/msp430gcc
 bin                 lib                        Revisions_MSPDebugStack.txt
 common              libexec                    rollbackBackupDirectory
 docs                msp430.dat                 share
 examples            msp430-elf                 Software_License_Agreement.pdf
'GPLv3 Notice.txt'   MSP430-GCC_manifest.html   uninstall
 include            'Release Notes.txt'         uninstall.dat
 install_scripts     Revisions_Header.txt       version.properties
$ ls include/
cc430f5123.h             msp430f5308.ld                    msp430fr2633.ld
cc430f5123.ld            msp430f5308_symbols.ld            msp430fr2633_symbols.ld
cc430f5123_symbols.ld    msp430f5309.h                     msp430fr2672.h
cc430f5125.h             msp430f5309.ld                    msp430fr2672.ld
$ ls msp430-elf/
bin  include  lib
...

```