### PR TITLE
[MSP430] Toolchain description updates for clang-rt

### DIFF
--- a/clang/lib/Basic/Targets/MSP430.cpp
+++ b/clang/lib/Basic/Targets/MSP430.cpp
@@ -29,5 +29,6 @@ void MSP430TargetInfo::getTargetDefines(const LangOptions &Opts,
                                         MacroBuilder &Builder) const {
   Builder.defineMacro("MSP430");
   Builder.defineMacro("__MSP430__");
+  Builder.defineMacro("__ELF__");
   // FIXME: defines for different 'flavours' of MCU
 }

--- a/clang/lib/Driver/ToolChains/MSP430.cpp
+++ b/clang/lib/Driver/ToolChains/MSP430.cpp
@@ -219,7 +219,7 @@ void msp430::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   CmdArgs.push_back("--start-group");
   CmdArgs.push_back(Args.MakeArgString(getHWMultLib(Args)));
-  CmdArgs.push_back("-lgcc");
+  AddRunTimeLibs(ToolChain, D, CmdArgs, Args);
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs)) {
     CmdArgs.push_back("-lc");
     CmdArgs.push_back("-lcrt");
@@ -231,7 +231,7 @@ void msp430::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     const char *crtend = Args.hasArg(options::OPT_fexceptions) ?
           "crtend.o" : "crtend_no_eh.o";
     CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath(crtend)));
-    CmdArgs.push_back("-lgcc");
+    AddRunTimeLibs(ToolChain, D, CmdArgs, Args);
   }
   CmdArgs.push_back("-o");
   CmdArgs.push_back(Output.getFilename());

--- a/clang/lib/Driver/ToolChains/MSP430.h
+++ b/clang/lib/Driver/ToolChains/MSP430.h
@@ -40,6 +40,11 @@ public:
   bool isPIEDefault() const override { return false; }
   bool isPICDefaultForced() const override { return true; }
 
+  UnwindLibType
+  GetUnwindLibType(const llvm::opt::ArgList &Args) const override {
+    return UNW_None;
+  }
+
 protected:
   Tool *buildLinker() const override;
 

--- a/clang/test/Driver/msp430-toolchain.c
+++ b/clang/test/Driver/msp430-toolchain.c
@@ -20,6 +20,18 @@
 // RUN:   --gcc-toolchain=%S/Inputs/basic_msp430_tree --sysroot="" 2>&1 \
 // RUN:   | FileCheck -check-prefix=MSP430-EXC %s
 
+// RUN: %clang %s -### -no-canonical-prefixes -target msp430 --rtlib=compiler-rt \
+// RUN:   --gcc-toolchain=%S/Inputs/basic_msp430_tree --sysroot="" 2>&1 \
+// RUN:   | FileCheck -check-prefix=MSP430-CLANG-RT %s
+
+// MSP430-CLANG-RT: "{{.*}}Inputs/basic_msp430_tree/lib/gcc/msp430-elf/8.3.1/../../..{{/|\\\\}}..{{/|\\\\}}bin{{/|\\\\}}msp430-elf-ld"
+// MSP430-CLANG-RT: "-L{{.*}}/Inputs/basic_msp430_tree/lib/gcc/msp430-elf/8.3.1/430"
+// MSP430-CLANG-RT: "-L{{.*}}/Inputs/basic_msp430_tree/lib/gcc/msp430-elf/8.3.1/../../..{{/|\\\\}}..{{/|\\\\}}msp430-elf{{/|\\\\}}lib/430"
+// MSP430-CLANG-RT: "{{.*}}/Inputs/basic_msp430_tree/lib/gcc/msp430-elf/8.3.1/../../..{{/|\\\\}}..{{/|\\\\}}msp430-elf{{/|\\\\}}lib/430{{/|\\\\}}crt0.o"
+// MSP430-CLANG-RT: "{{.*}}/Inputs/basic_msp430_tree/lib/gcc/msp430-elf/8.3.1/430{{/|\\\\}}crtbegin_no_eh.o"
+// MSP430-CLANG-RT: "--start-group" "-lmul_none" "{{.*}}libclang_rt.builtins-msp430.a" "-lc" "-lcrt" "-lnosys" "--end-group"
+// MSP430-CLANG-RT: "{{.*}}/Inputs/basic_msp430_tree/lib/gcc/msp430-elf/8.3.1/430{{/|\\\\}}crtend_no_eh.o" "{{.*}}libclang_rt.builtins-msp430.a"
+
 // MSP430-EXC: "{{.*}}Inputs/basic_msp430_tree/lib/gcc/msp430-elf/8.3.1/../../..{{/|\\\\}}..{{/|\\\\}}bin{{/|\\\\}}msp430-elf-ld"
 // MSP430-EXC: "-L{{.*}}/Inputs/basic_msp430_tree/lib/gcc/msp430-elf/8.3.1/430/exceptions"
 // MSP430-EXC: "-L{{.*}}/Inputs/basic_msp430_tree/lib/gcc/msp430-elf/8.3.1/../../..{{/|\\\\}}..{{/|\\\\}}msp430-elf{{/|\\\\}}lib/430/exceptions"


### PR DESCRIPTION
In preparation for compiler-rt built-ins support on MSP430, push less questionable patch first, so my other experimental branches can be rebased onto it.