### PR TITLE
Emit DWARF for MSP430 target

### DIFF
--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -424,6 +424,14 @@ public:
   /// Get the code pointer size in bytes.
   unsigned getCodePointerSize() const { return CodePointerSize; }
 
+  /// Get the pointer size in bytes to use when emitting DWARF.
+  /// On some targets where CodePointerSize == 2 (such as AVR and MSP430)
+  /// gcc emits .debug_info with addr_size = 0x04.
+  /// llvm-dwarfdump expects that as well to parse .debug_info.
+  unsigned getCodePointerSizeForDwarf() const {
+    return std::max(CodePointerSize, 4U);
+  }
+
   /// Get the callee-saved register stack slot
   /// size in bytes.
   unsigned getCalleeSaveStackSlotSize() const {

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinterDwarf.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinterDwarf.cpp
@@ -181,7 +181,7 @@ void AsmPrinter::emitDwarfStringOffset(DwarfStringPoolEntry S) const {
 }
 
 void AsmPrinter::emitDwarfOffset(const MCSymbol *Label, uint64_t Offset) const {
-  emitLabelPlusOffset(Label, Offset, MAI->getCodePointerSize());
+  emitLabelPlusOffset(Label, Offset, MAI->getCodePointerSizeForDwarf());
 }
 
 void AsmPrinter::emitCallSiteOffset(const MCSymbol *Hi, const MCSymbol *Lo,

--- a/llvm/lib/CodeGen/AsmPrinter/DIE.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DIE.cpp
@@ -500,7 +500,7 @@ unsigned DIELabel::SizeOf(const AsmPrinter *AP, dwarf::Form Form) const {
   if (Form == dwarf::DW_FORM_data4) return 4;
   if (Form == dwarf::DW_FORM_sec_offset) return 4;
   if (Form == dwarf::DW_FORM_strp) return 4;
-  return AP->MAI->getCodePointerSize();
+  return AP->MAI->getCodePointerSizeForDwarf();
 }
 
 LLVM_DUMP_METHOD
@@ -539,7 +539,7 @@ unsigned DIEDelta::SizeOf(const AsmPrinter *AP, dwarf::Form Form) const {
   if (Form == dwarf::DW_FORM_data4) return 4;
   if (Form == dwarf::DW_FORM_sec_offset) return 4;
   if (Form == dwarf::DW_FORM_strp) return 4;
-  return AP->MAI->getCodePointerSize();
+  return AP->MAI->getCodePointerSizeForDwarf();
 }
 
 LLVM_DUMP_METHOD
@@ -674,7 +674,7 @@ unsigned DIEEntry::SizeOf(const AsmPrinter *AP, dwarf::Form Form) const {
     return getULEB128Size(Entry->getOffset());
   case dwarf::DW_FORM_ref_addr:
     if (AP->getDwarfVersion() == 2)
-      return AP->MAI->getCodePointerSize();
+      return AP->MAI->getCodePointerSizeForDwarf();
     switch (AP->OutStreamer->getContext().getDwarfFormat()) {
     case dwarf::DWARF32:
       return 4;
@@ -808,7 +808,7 @@ unsigned DIELocList::SizeOf(const AsmPrinter *AP, dwarf::Form Form) const {
     return 4;
   if (Form == dwarf::DW_FORM_sec_offset)
     return 4;
-  return AP->MAI->getCodePointerSize();
+  return AP->MAI->getCodePointerSizeForDwarf();
 }
 
 /// EmitValue - Emit label value.

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2422,7 +2422,7 @@ void DwarfDebug::emitDebugLocEntry(ByteStreamer &Streamer,
   // need to reference a base_type DIE the offset of that DIE is not yet known.
   // To deal with this we instead insert a placeholder early and then extract
   // it here and replace it with the real reference.
-  unsigned PtrSize = Asm->MAI->getCodePointerSize();
+  unsigned PtrSize = Asm->MAI->getCodePointerSizeForDwarf();
   DWARFDataExtractor Data(StringRef(DebugLocs.getBytes(Entry).data(),
                                     DebugLocs.getBytes(Entry).size()),
                           Asm->getDataLayout().isLittleEndian(), PtrSize);
@@ -2588,7 +2588,7 @@ static void emitRangeList(
     bool ShouldUseBaseAddress,
     PayloadEmitter EmitPayload) {
 
-  auto Size = Asm->MAI->getCodePointerSize();
+  auto Size = Asm->MAI->getCodePointerSizeForDwarf();
   bool UseDwarf5 = DD.getDwarfVersion() >= 5;
 
   // Emit our symbol so we can find the beginning of the range.
@@ -2832,7 +2832,7 @@ void DwarfDebug::emitDebugARanges() {
   Asm->OutStreamer->SwitchSection(
       Asm->getObjFileLowering().getDwarfARangesSection());
 
-  unsigned PtrSize = Asm->MAI->getCodePointerSize();
+  unsigned PtrSize = Asm->MAI->getCodePointerSizeForDwarf();
 
   // Build a list of CUs used.
   std::vector<DwarfCompileUnit *> CUs;

--- a/llvm/lib/Object/RelocationResolver.cpp
+++ b/llvm/lib/Object/RelocationResolver.cpp
@@ -127,6 +127,30 @@ static uint64_t resolveMips64(RelocationRef R, uint64_t S, uint64_t A) {
   }
 }
 
+static bool supportsMSP430(uint64_t Type) {
+  switch (Type) {
+  case ELF::R_MSP430_32:
+  case ELF::R_MSP430_16:
+  case ELF::R_MSP430_16_BYTE:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static uint64_t resolveMSP430(RelocationRef R, uint64_t S, uint64_t A) {
+  switch (R.getType()) {
+  case ELF::R_MSP430_32:
+    return (S + getELFAddend(R)) & 0xFFFFFFFF;
+  case ELF::R_MSP430_16:
+    return (S + getELFAddend(R)) & 0xFFFF;
+  case ELF::R_MSP430_16_BYTE:
+    return (S + getELFAddend(R)) & 0xFFFF;
+  default:
+    llvm_unreachable("Invalid relocation type");
+  }
+}
+
 static bool supportsPPC64(uint64_t Type) {
   switch (Type) {
   case ELF::R_PPC64_ADDR32:
@@ -591,6 +615,8 @@ getRelocationResolver(const ObjectFile &Obj) {
     case Triple::mipsel:
     case Triple::mips:
       return {supportsMips32, resolveMips32};
+    case Triple::msp430:
+      return {supportsMSP430, resolveMSP430};
     case Triple::sparc:
       return {supportsSparc32, resolveSparc32};
     case Triple::hexagon:

--- a/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCAsmInfo.cpp
+++ b/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCAsmInfo.cpp
@@ -24,4 +24,6 @@ MSP430MCAsmInfo::MSP430MCAsmInfo(const Triple &TT,
 
   AlignmentIsInBytes = false;
   UsesELFSectionDirectiveForBSS = true;
+
+  SupportsDebugInformation = true;
 }

--- a/llvm/lib/Target/MSP430/MSP430RegisterInfo.td
+++ b/llvm/lib/Target/MSP430/MSP430RegisterInfo.td
@@ -15,6 +15,7 @@ class MSP430Reg<bits<4> num, string n, list<string> alt = []> : Register<n> {
   let Namespace = "MSP430";
   let HWEncoding{3-0} = num;
   let AltNames = alt;
+  let DwarfNumbers = [num];
 }
 
 class MSP430RegWithSubregs<bits<4> num, string n, list<Register> subregs,
@@ -24,6 +25,7 @@ class MSP430RegWithSubregs<bits<4> num, string n, list<Register> subregs,
   let Namespace = "MSP430";
   let HWEncoding{3-0} = num;
   let AltNames = alt;
+  let DwarfNumbers = [num];
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/DebugInfo/MSP430/dwarf-basics.ll
+++ b/llvm/test/DebugInfo/MSP430/dwarf-basics.ll
@@ -1,0 +1,130 @@
+; RUN: llc --filetype=obj -o %t < %s 
+; RUN: llvm-dwarfdump %t | FileCheck %s
+
+; This file is a modified version of LLVM IR produced from
+;
+;  struct X {
+;    void *a;
+;  };
+;
+;  int f(long y, struct X *p)
+;  {
+;    return 42;
+;  }
+;
+; By command like this
+;
+;   clang -target msp430 -S -emit-llvm -g test.c -Os
+
+
+; CHECK: file format elf32-msp430
+
+; CHECK: .debug_info contents:
+; CHECK: Compile Unit: {{.*}} format = DWARF32, {{.*}} addr_size = 0x04
+
+; Some DW_AT_* lines and NULLs are completely omitted
+
+; CHECK: DW_TAG_compile_unit
+; CHECK:   DW_AT_producer    ("clang version {{.*}}")
+; CHECK:   DW_AT_language    (DW_LANG_C99)
+; CHECK:   DW_AT_name        ("test.c")
+; CHECK:   DW_AT_comp_dir    ("/tmp")
+
+; CHECK:   DW_TAG_subprogram
+; CHECK:     DW_AT_name      ("f")
+; CHECK:     DW_AT_decl_file ("/tmp/test.c")
+; CHECK:     DW_AT_decl_line (5)
+; CHECK:     DW_AT_prototyped        (true)
+; CHECK:     DW_AT_type      (0x{{.*}} "int")
+; CHECK:     DW_AT_external  (true)
+
+; CHECK:     DW_TAG_formal_parameter
+; CHECK:       DW_AT_location        (0x00000000: 
+; CHECK:          [0x00000000, 0x00000004): DW_OP_reg12 R12B)
+; CHECK:       DW_AT_name    ("y")
+; CHECK:       DW_AT_decl_file       ("/tmp/test.c")
+; CHECK:       DW_AT_decl_line       (5)
+; CHECK:       DW_AT_type    (0x{{.*}} "long int")
+
+; CHECK:     DW_TAG_formal_parameter
+; CHECK:       DW_AT_location        (DW_OP_reg14 R14B)
+; CHECK:       DW_AT_name    ("p")
+; CHECK:       DW_AT_decl_file       ("/tmp/test.c")
+; CHECK:       DW_AT_decl_line       (5)
+; CHECK:       DW_AT_type    (0x{{.*}} "X*")
+
+; CHECK:   DW_TAG_base_type
+; CHECK:     DW_AT_name      ("int")
+; CHECK:     DW_AT_encoding  (DW_ATE_signed)
+; CHECK:     DW_AT_byte_size (0x02)
+
+; CHECK:   DW_TAG_base_type
+; CHECK:     DW_AT_name      ("long int")
+; CHECK:     DW_AT_encoding  (DW_ATE_signed)
+; CHECK:     DW_AT_byte_size (0x04)
+
+; CHECK:   DW_TAG_pointer_type
+; CHECK:     DW_AT_type      (0x{{.*}} "X")
+; CHECK:     DW_AT_byte_size (0x02)
+
+; CHECK:   DW_TAG_structure_type
+; CHECK:     DW_AT_name      ("X")
+; CHECK:     DW_AT_byte_size (0x02)
+; CHECK:     DW_AT_decl_file ("/tmp/test.c")
+; CHECK:     DW_AT_decl_line (1)
+
+; CHECK:     DW_TAG_member
+; CHECK:       DW_AT_name    ("a")
+; CHECK:       DW_AT_type    (0x{{.*}} "*")
+; CHECK:       DW_AT_decl_file       ("/tmp/test.c")
+; CHECK:       DW_AT_decl_line       (2)
+; CHECK:       DW_AT_data_member_location    (0x00)
+
+; CHECK:   DW_TAG_pointer_type
+; Please note that DWARF data themselves are written with 32-bit pointers
+; CHECK:     DW_AT_byte_size (0x02)
+
+source_filename = "test.c"
+target datalayout = "e-m:e-p:16:16-i32:16-i64:16-f32:16-f64:16-a:8-n8:16-S16"
+target triple = "msp430"
+
+%struct.X = type { i8* }
+
+define i16 @f(i32 %y, %struct.X* %p) #0 !dbg !7 {
+entry:
+  call void @llvm.dbg.value(metadata i32 %y, metadata !18, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.value(metadata %struct.X* %p, metadata !19, metadata !DIExpression()), !dbg !20
+  ret i16 42, !dbg !21
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata) #1
+
+attributes #0 = { norecurse nounwind optsize readnone "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 11.0.0 (git@github.com:access-softek/llvm-project.git 3b52ae04cefb56b1f7b690b4680f5ba1f6232c78)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "test.c", directory: "/tmp")
+!2 = !{}
+!3 = !{i32 7, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 2}
+!6 = !{!"clang version 11.0.0 (git@github.com:...)"}
+!7 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 5, type: !8, scopeLine: 6, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !17)
+!8 = !DISubroutineType(types: !9)
+!9 = !{!10, !11, !12}
+!10 = !DIBasicType(name: "int", size: 16, encoding: DW_ATE_signed)
+!11 = !DIBasicType(name: "long int", size: 32, encoding: DW_ATE_signed)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 16)
+!13 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "X", file: !1, line: 1, size: 16, elements: !14)
+!14 = !{!15}
+!15 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !13, file: !1, line: 2, baseType: !16, size: 16)
+!16 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 16)
+!17 = !{!18, !19}
+!18 = !DILocalVariable(name: "y", arg: 1, scope: !7, file: !1, line: 5, type: !11)
+!19 = !DILocalVariable(name: "p", arg: 2, scope: !7, file: !1, line: 5, type: !12)
+!20 = !DILocation(line: 0, scope: !7)
+!21 = !DILocation(line: 7, column: 3, scope: !7)


### PR DESCRIPTION
Turned out, fixing #26 was not so trivial. While implementing several relocation types was quite easy, the real issue was the fact that LLVM emits the `.debug_info` with `addr_size` equal to `MCAsmInfo::CodePointerSize`. This even produces correct debug info (at least `msp430-elf-gdb` can use it to answer various questions about the program state).

The problems start when trying to test it. Looks like `llvm-dwarfdump` expects either DWARF32 with addr_size = 4 or DWARF64 with addr_size = 8, so it cannot print the contents of `.debug_info`. But it can dump debug info from object files produced by msp430-elf-gcc because it uses DWARF32 with addr_size = 4.

So, this PR tries to introduce another pointer size that is used for DWARF emitting. It may be worth to just change `CodePointerSize` from 2 to 4 for MSP430 (dropping the first of three commits and significantly simplifying the review) but at least `AsmPrinter::doFinalization` seems to use it exactly as a native pointer size.

Meanwhile, the same issue was with AVR target: I installed `avr-gcc` from system repository and it uses DWARF32 with addr_size = 4 as well. AVR backend for LLVM, on the other hand, cannot parse its own debug info. (What is pointer size on AVR32?)

On possible regressions:
* I need to recheck the update of `MSP430MCAsmInfo ` class according to LLVM guidelines (what compatibility is required and how to achieve it)
* this PR is expected to be NFC for targets with CodePointerSize >= 4
  * the only mainline targets that are not covered are MSP430 and AVR, both seems to function better with this patch
  * private target implementations can become broken, on the other hand (how is this handled?)