### PR TITLE
[clang] Fix warnings related to enum in `clang::PointerAuthQualifier`

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -141,7 +141,7 @@ using CanQualType = CanQual<Type>;
 
 /// Pointer-authentication qualifiers.
 class PointerAuthQualifier {
-  enum {
+  enum : uint32_t {
     EnabledShift = 0,
     EnabledBits = 1,
     EnabledMask = 1 << EnabledShift,
@@ -165,7 +165,7 @@ class PointerAuthQualifier {
     KeyMask = ((1 << KeyBits) - 1) << KeyShift,
     DiscriminatorShift = KeyShift + KeyBits,
     DiscriminatorBits = 16,
-    DiscriminatorMask = ((1 << DiscriminatorBits) - 1) << DiscriminatorShift,
+    DiscriminatorMask = ((1u << DiscriminatorBits) - 1) << DiscriminatorShift,
   };
 
   // bits:     |0      |1      |2..3              |4          |5                |6..15|   16...31   |
@@ -193,7 +193,9 @@ class PointerAuthQualifier {
                        PointerAuthenticationMode authenticationMode,
                        bool isIsaPointer, bool authenticatesNullValues)
       : Data(EnabledMask |
-             (isAddressDiscriminated ? AddressDiscriminatedMask : 0) |
+             (isAddressDiscriminated
+                  ? static_cast<uint32_t>(AddressDiscriminatedMask)
+                  : 0) |
              (key << KeyShift) |
              (unsigned(authenticationMode) << AuthenticationModeShift) |
              (extraDiscriminator << DiscriminatorShift) |


### PR DESCRIPTION
Due to location in clang/include/clang/AST/Type.h header, the following warnings cluttered the build log and made identifying other meaningful compiler messages hard.

Warning 1:

```
/path/to/llvm-project/clang/include/clang/AST/Type.h:182:77: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
  180 |   static_assert((EnabledMask + AddressDiscriminatedMask +
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  181 |                  AuthenticationModeMask + IsaPointerMask +
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  182 |                  AuthenticatesNullValuesMask + KeyMask + DiscriminatorMask) ==
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
  183 |                     0xFFFFFFFF,
      |                     ~~~~~~~~~~
```

Warning 2:

```
/path/to/llvm-project/clang/include/clang/AST/Type.h:196:38: warning: enumerated and non-enumerated type in conditional expression [-Wextra]
  196 |              (isAddressDiscriminated ? AddressDiscriminatedMask : 0) |
      |               ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```