### PR TITLE
[clang] Always select ud2 instruction for trap

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -470,6 +470,9 @@ static bool initTargetOptions(DiagnosticsEngine &Diags,
   Options.JMCInstrument = CodeGenOpts.JMCInstrument;
   Options.XCOFFReadOnlyPointers = CodeGenOpts.XCOFFReadOnlyPointers;
 
+  if (LangOpts.Kernel)
+    Options.TrapUnreachable = true;
+
   switch (CodeGenOpts.getSwiftAsyncFramePointer()) {
   case CodeGenOptions::SwiftAsyncFramePointerKind::Auto:
     Options.SwiftAsyncFramePointer =

--- a/clang/test/CodeGen/MSKernel/noreturn.c
+++ b/clang/test/CodeGen/MSKernel/noreturn.c
@@ -1,0 +1,24 @@
+// REQUIRES: x86-registered-target
+// RUN: %clang_cc1 -fms-kernel -fms-extensions -triple x86_64-windows-msvc -O2 -S %s -o - | FileCheck %s
+
+// CHECK-LABEL: my_noreturn_func:
+// CHECK:       callq bugcheck
+// CHECK-NEXT:  ud2
+
+// CHECK-LABEL: my_noreturn_func2:
+// CHECK:       movl $0, (%rax)
+// CHECK-NEXT:  ud2
+
+void bugcheck(int code);
+
+extern long volatile *gtrap;
+
+__declspec(noreturn) void my_noreturn_func(void) {
+    bugcheck(0x42);
+}
+
+
+__declspec(noreturn) void my_noreturn_func2(void) {
+    *gtrap = 0;
+}
+


### PR DESCRIPTION
Patch selects ud2 (undefined instruction) for LLVM IR unreachable under X86. The guarantees that a noreturn function never returns.