### PR TITLE
[mlir][dxsa] Add dcl_indexable_temp instruction

### DIFF
--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSABitwiseOps.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSABitwiseOps.td
@@ -1,0 +1,38 @@
+//===- DXSABitwiseOps.td - DXSA bitwise ops -------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Bitwise instructions of the DXSA dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_DXSA_IR_DXSABITWISEOPS
+#define MLIR_DIALECT_DXSA_IR_DXSABITWISEOPS
+
+include "mlir/Dialect/DXSA/IR/DXSAOpBase.td"
+
+//===----------------------------------------------------------------------===//
+// dxsa.and
+//===----------------------------------------------------------------------===//
+
+def DXSA_And : DXSA_BinaryOp<"and"> {
+  let summary = "component-wise logical AND";
+  let description = [{
+    The `dxsa.and` operation computes the component-wise logical AND
+    of each pair of 32-bit values from `$rhs` and `$lhs`.
+    32-bit results placed in `$dst`.
+
+    Example:
+
+    ```mlir
+    dxsa.and r<0>, r<1>, r<2>
+    dxsa.and r<0, <x, y>>, r<1, <y, z, x, w>>, r<2, <z, z, z, z>>
+    ```
+  }];
+}
+
+#endif // MLIR_DIALECT_DXSA_IR_DXSABITWISEOPS

--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSAOps.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSAOps.td
@@ -12,6 +12,7 @@
 include "mlir/Dialect/DXSA/IR/DXSAOpBase.td"
 include "mlir/Dialect/DXSA/IR/DXSATypes.td"
 include "mlir/Dialect/DXSA/IR/DXSAFPArithOps.td"
+include "mlir/Dialect/DXSA/IR/DXSABitwiseOps.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
 include "mlir/IR/EnumAttr.td"

--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSAOps.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSAOps.td
@@ -1301,4 +1301,32 @@ def DXSA_DclResourceRaw : DXSA_Op<"dcl_resource_raw"> {
   let hasVerifier = 1;
 }
 
+def DXSA_DclIndexableTemp : DXSA_Op<"dcl_indexable_temp"> {
+  let summary = "declares a temporary register array";
+  let description = [{
+    The `dxsa.dcl_indexable_temp` operation declares a temporary register array.
+    Each temporary register array to be used in the shader must be declared.
+    - `$id` identifies the `x#` register being declared.
+    - `$size` is an integer that defines how many elements are in
+    this array of 32-bit 4-component indexable temp storage that is being declared.
+    - `$num_components` is the number of components (1..4) used per element;
+    omitted from the textual form when equal to 4.
+
+    Example:
+
+    ```mlir
+    dxsa.dcl_indexable_temp x<0>[1], 1
+    dxsa.dcl_indexable_temp x<1>[23], 2
+    dxsa.dcl_indexable_temp x<7>[4096]
+    ```
+  }];
+  let arguments = (ins
+      I32Attr:$id,
+      ConfinedAttr<I32Attr, [IntPositive, IntMaxValue<4096>]>:$size,
+      DefaultValuedAttr<
+          ConfinedAttr<I32Attr, [IntPositive, IntMaxValue<4>]>,
+          "4">:$num_components);
+  let assemblyFormat = "`x` `<` $id `>` `` `[` $size `]` (`,` $num_components^)? attr-dict";
+}
+
 #endif // DXSA_OPS

--- a/mlir/lib/Target/DXSA/BinaryParser.cpp
+++ b/mlir/lib/Target/DXSA/BinaryParser.cpp
@@ -926,6 +926,14 @@ public:
                                         toAttr(ubound), toAttr(space));
   }
 
+  Instruction buildDclIndexableTemp(uint32_t id, uint32_t size,
+                                    uint32_t numComponents, Location loc) {
+    return dxsa::DclIndexableTemp::create(
+        builder, loc, builder.getI32IntegerAttr(id),
+        builder.getI32IntegerAttr(size),
+        builder.getI32IntegerAttr(numComponents));
+  }
+
 private:
   MLIRContext *context;
   OpBuilder builder;
@@ -1965,6 +1973,16 @@ public:
     return builder.buildDclResourceRaw(id, lbound, ubound, space, loc);
   }
 
+  FailureOr<Instruction> parseDclIndexableTemp(Location loc) {
+    auto id = parseToken();
+    FAILURE_IF_FAILED(id);
+    auto size = parseToken();
+    FAILURE_IF_FAILED(size);
+    auto numComponents = parseToken();
+    FAILURE_IF_FAILED(numComponents);
+    return builder.buildDclIndexableTemp(*id, *size, *numComponents, loc);
+  }
+
   OptionalParseResult parseDclInstruction(uint32_t opcodeToken, Location loc,
                                           Instruction &out) {
     FailureOr<Instruction> result;
@@ -2064,6 +2082,9 @@ public:
       break;
     case D3D11_SB_OPCODE_DCL_RESOURCE_RAW:
       result = parseDclResourceRaw(loc);
+      break;
+    case D3D10_SB_OPCODE_DCL_INDEXABLE_TEMP:
+      result = parseDclIndexableTemp(loc);
       break;
     default:
       return std::nullopt;

--- a/mlir/lib/Target/DXSA/BinaryParser.cpp
+++ b/mlir/lib/Target/DXSA/BinaryParser.cpp
@@ -2109,6 +2109,10 @@ public:
     if (opcode >= D3D10_SB_NUM_OPCODES)
       return emitError(getLocation(), "unknown opcode: ") << opcode;
 
+    if (failed(verifyInstructionLengthFitsBufferSize(
+            beginOffset, instructionLengthInTokens)))
+      return failure();
+
     Instruction dclInstruction;
     auto parseResult =
         parseDclInstruction(*opcodeToken0, getLocation(), dclInstruction);
@@ -2269,6 +2273,14 @@ public:
     FAILURE_IF_FAILED(parseToken()); // VersionToken
     FAILURE_IF_FAILED(parseToken()); // LengthToken
     return std::optional<ProgramHeader>{{*programType, major, minor}};
+  }
+
+  LogicalResult verifyInstructionLengthFitsBufferSize(size_t beginOffset,
+                                                      uint32_t length) {
+    if (beginOffset + static_cast<size_t>(length) * tokenSize > buffer.size())
+      return emitError(getLocation(),
+                       "instruction length exceeds program size");
+    return success();
   }
 
   LogicalResult verifyInstructionLength(size_t beginOffset, uint32_t length) {

--- a/mlir/lib/Target/DXSA/BinaryParser.cpp
+++ b/mlir/lib/Target/DXSA/BinaryParser.cpp
@@ -1634,6 +1634,20 @@ public:
                                        fields->values, fields->values64);
   }
 
+  template <typename BinOpT>
+  FailureOr<Instruction> decodeBinaryOp(size_t beginOffset, uint32_t length,
+                                        uint32_t preciseMask, Location loc) {
+    auto dst = parseDstOperand();
+    FAILURE_IF_FAILED(dst);
+    auto lhs = parseSrcOperand();
+    FAILURE_IF_FAILED(lhs);
+    auto rhs = parseSrcOperand();
+    FAILURE_IF_FAILED(rhs);
+    if (failed(verifyInstructionLength(beginOffset, length)))
+      return failure();
+    return builder.buildBinaryOp<BinOpT>(*dst, *lhs, *rhs, preciseMask, loc);
+  }
+
   template <typename BinOpT, typename BinOpSatT>
   FailureOr<Instruction>
   decodeSaturableBinaryOp(size_t beginOffset, uint32_t length, bool saturate,
@@ -2109,6 +2123,9 @@ public:
 
     unsigned numOperands = instrInfo[opcode].numOperands;
 
+#define BINARY_OP(OP)                                                          \
+  decodeBinaryOp<dxsa::OP>(beginOffset, instructionLengthInTokens,             \
+                           modifier.preciseMask, getLocation())
 #define SATURABLE_BINARY_OP(OP)                                                \
   decodeSaturableBinaryOp<dxsa::OP, dxsa::OP##Sat>(                            \
       beginOffset, instructionLengthInTokens, modifier.saturate,               \
@@ -2119,8 +2136,11 @@ public:
       return SATURABLE_BINARY_OP(Add);
     case D3D10_SB_OPCODE_DIV:
       return SATURABLE_BINARY_OP(Div);
+    case D3D10_SB_OPCODE_AND:
+      return BINARY_OP(And);
     }
 #undef SATURABLE_BINARY_OP
+#undef BINARY_OP
 
     SmallVector<Operand, 8> operands;
     for (unsigned i = 0; i < numOperands; ++i) {

--- a/mlir/test/Target/DXSA/and.mlir
+++ b/mlir/test/Target/DXSA/and.mlir
@@ -1,0 +1,10 @@
+// RUN: mlir-translate --import-dxsa-hex %s | FileCheck %s
+// RUN: mlir-translate --import-dxsa-hex %s | mlir-opt --verify-roundtrip
+
+// CHECK:      dxsa.module {
+
+// CHECK-NEXT:   dxsa.and r<0>, r<1>, r<2>
+0x07000001, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001, 0x00100e46, 0x00000002,
+// CHECK-NEXT:   dxsa.and r<0>, r<1>, l(0xFF, 0xFF, 0xFF, 0xFF)
+0x0a000001, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001, 0x00004002, 0x000000ff, 0x000000ff, 0x000000ff, 0x000000ff
+// CHECK-NEXT: }

--- a/mlir/test/Target/DXSA/dcl_indexable_temp.mlir
+++ b/mlir/test/Target/DXSA/dcl_indexable_temp.mlir
@@ -1,0 +1,13 @@
+// RUN: mlir-translate --import-dxsa-hex %s | FileCheck %s
+// RUN: mlir-translate --import-dxsa-hex %s | mlir-opt --verify-roundtrip
+
+// CHECK:      dxsa.module {
+// CHECK-NEXT:   dxsa.dcl_indexable_temp x<0>[1], 1
+0x04000069, 0x00000000, 0x00000001, 0x00000001
+// CHECK-NEXT:   dxsa.dcl_indexable_temp x<1>[23], 2
+0x04000069, 0x00000001, 0x00000017, 0x00000002
+// CHECK-NEXT:   dxsa.dcl_indexable_temp x<2>[16]
+0x04000069, 0x00000002, 0x00000010, 0x00000004
+// CHECK-NEXT:   dxsa.dcl_indexable_temp x<7>[4096]
+0x04000069, 0x00000007, 0x00001000, 0x00000004
+// CHECK-NEXT: }

--- a/mlir/test/Target/DXSA/dcl_indexable_temp_invalid.mlir
+++ b/mlir/test/Target/DXSA/dcl_indexable_temp_invalid.mlir
@@ -1,0 +1,24 @@
+// RUN: mlir-opt %s -split-input-file -verify-diagnostics
+
+// expected-error@+1 {{attribute 'size' failed to satisfy constraint: 32-bit signless integer attribute whose value is positive whose maximum value is 4096}}
+dxsa.dcl_indexable_temp x<0>[0], 1
+
+// -----
+
+// expected-error@+1 {{attribute 'size' failed to satisfy constraint: 32-bit signless integer attribute whose value is positive whose maximum value is 4096}}
+dxsa.dcl_indexable_temp x<0>[4097], 1
+
+// -----
+
+// expected-error@+1 {{attribute 'num_components' failed to satisfy constraint: 32-bit signless integer attribute whose value is positive whose maximum value is 4}}
+dxsa.dcl_indexable_temp x<0>[16], 0
+
+// -----
+
+// expected-error@+1 {{attribute 'num_components' failed to satisfy constraint: 32-bit signless integer attribute whose value is positive whose maximum value is 4}}
+dxsa.dcl_indexable_temp x<0>[16], 5
+
+// -----
+
+// expected-error@+1 {{expected 'x'}}
+dxsa.dcl_indexable_temp r<0>[16], 1


### PR DESCRIPTION
Example:

```mlir
    dxsa.dcl_indexable_temp x<0>[1], 1
    dxsa.dcl_indexable_temp x<1>[23], 2
    dxsa.dcl_indexable_temp x<7>[4096]
```