### PR TITLE
[mlir][dxsa] Add "--import-dxsa-hex" translation

### DIFF
--- a/mlir/include/mlir/InitAllTranslations.h
+++ b/mlir/include/mlir/InitAllTranslations.h
@@ -22,6 +22,7 @@ void registerFromLLVMIRTranslation();
 void registerFromSPIRVTranslation();
 void registerFromWasmTranslation();
 void registerFromDxsaBinTranslation();
+void registerFromDxsaHexTranslation();
 void registerToCppTranslation();
 void registerToDxsaBinTranslation();
 void registerToLLVMIRTranslation();
@@ -41,6 +42,7 @@ inline void registerAllTranslations() {
     registerIRDLToCppTranslation();
     registerFromWasmTranslation();
     registerFromDxsaBinTranslation();
+    registerFromDxsaHexTranslation();
     registerToCppTranslation();
     registerToDxsaBinTranslation();
     registerToLLVMIRTranslation();

--- a/mlir/include/mlir/Target/DXSA/BinaryParser.h
+++ b/mlir/include/mlir/Target/DXSA/BinaryParser.h
@@ -21,6 +21,13 @@ namespace mlir::dxsa {
 OwningOpRef<dxsa::ModuleOp> deserialize(llvm::SourceMgr &source,
                                         MLIRContext *context);
 
+/// Deserializes a textual listing of little-endian hex DWORDs,
+/// separated by whitespace or comma.
+/// This method is used in tests to store hexadeciman tokens representation
+/// right inside the text body.
+OwningOpRef<dxsa::ModuleOp> deserializeHex(llvm::SourceMgr &source,
+                                           MLIRContext *context);
+
 /// Serializes the given MLIR \p moduleOp and writes to \p output.
 LogicalResult serialize(mlir::ModuleOp moduleOp, raw_ostream &output);
 } // namespace mlir::dxsa

--- a/mlir/lib/Target/DXSA/BinaryParser.cpp
+++ b/mlir/lib/Target/DXSA/BinaryParser.cpp
@@ -12,11 +12,14 @@
 #include "mlir/IR/Location.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/bit.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DebugLog.h"
 #include "llvm/Support/Endian.h"
+#include "llvm/Support/EndianStream.h"
 #include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <optional>
 
@@ -2259,19 +2262,8 @@ private:
 };
 
 namespace mlir::dxsa {
-OwningOpRef<ModuleOp> deserialize(llvm::SourceMgr &source,
-                                  MLIRContext *context) {
-
-  if (source.getNumBuffers() != 1) {
-    emitError(UnknownLoc::get(context), "one source file should be provided");
-    return nullptr;
-  }
-
-  uint32_t sourceBufId = source.getMainFileID();
-  StringRef buffer = source.getMemoryBuffer(sourceBufId)->getBuffer();
-  StringAttr name = StringAttr::get(
-      context, source.getMemoryBuffer(sourceBufId)->getBufferIdentifier());
-
+static OwningOpRef<ModuleOp> parseProgram(StringRef buffer, StringAttr name,
+                                          MLIRContext *context) {
   // FIXME:
   context->allowUnregisteredDialects();
   context->loadAllAvailableDialects();
@@ -2283,4 +2275,60 @@ OwningOpRef<ModuleOp> deserialize(llvm::SourceMgr &source,
     return {nullptr};
   return {*mod};
 }
+
+OwningOpRef<ModuleOp> deserialize(llvm::SourceMgr &source,
+                                  MLIRContext *context) {
+  if (source.getNumBuffers() != 1) {
+    emitError(UnknownLoc::get(context), "one source file should be provided");
+    return nullptr;
+  }
+
+  const auto *memBuffer = source.getMemoryBuffer(source.getMainFileID());
+  return parseProgram(
+      memBuffer->getBuffer(),
+      StringAttr::get(context, memBuffer->getBufferIdentifier()), context);
+}
+
+static FailureOr<std::string> hexDwordsToBytes(StringRef buffer,
+                                               StringAttr name) {
+  std::string bytes;
+  raw_string_ostream os(bytes);
+  support::endian::Writer writer(os, endianness::little);
+  static constexpr StringRef tokenDelimiters = ", \t\v\f\r";
+  SmallVector<StringRef> lines;
+  buffer.split(lines, '\n');
+  for (auto [index, line] : llvm::enumerate(lines)) {
+    StringRef rest = line.split("//").first;
+    auto [token, tail] = llvm::getToken(rest, tokenDelimiters);
+    while (!token.empty()) {
+      uint32_t value = 0;
+      if (token.getAsInteger(/*Radix=*/0, value)) {
+        auto column = token.data() - line.data() + 1;
+        return emitError(FileLineColLoc::get(name, index + 1, column),
+                         "invalid hex DWORD: ")
+               << token;
+      }
+      writer.write(value);
+      std::tie(token, tail) = llvm::getToken(tail, tokenDelimiters);
+    }
+  }
+  return bytes;
+}
+
+OwningOpRef<ModuleOp> deserializeHex(llvm::SourceMgr &source,
+                                     MLIRContext *context) {
+  if (source.getNumBuffers() != 1) {
+    emitError(UnknownLoc::get(context), "one source file should be provided");
+    return nullptr;
+  }
+
+  const auto *memBuffer = source.getMemoryBuffer(source.getMainFileID());
+  auto name = StringAttr::get(context, memBuffer->getBufferIdentifier());
+
+  auto bytes = hexDwordsToBytes(memBuffer->getBuffer(), name);
+  if (failed(bytes))
+    return nullptr;
+  return parseProgram(*bytes, name, context);
+}
+
 } // namespace mlir::dxsa

--- a/mlir/lib/Target/DXSA/TranslateRegistration.cpp
+++ b/mlir/lib/Target/DXSA/TranslateRegistration.cpp
@@ -24,6 +24,16 @@ void registerFromDxsaBinTranslation() {
       [](DialectRegistry &registry) { registry.insert<dxsa::DXSADialect>(); }};
 }
 
+void registerFromDxsaHexTranslation() {
+  TranslateToMLIRRegistration registration{
+      "import-dxsa-hex", "Translate a DXSA hex DWORD listing to MLIR",
+      [](llvm::SourceMgr &sourceMgr,
+         MLIRContext *context) -> OwningOpRef<Operation *> {
+        return dxsa::deserializeHex(sourceMgr, context);
+      },
+      [](DialectRegistry &registry) { registry.insert<dxsa::DXSADialect>(); }};
+}
+
 void registerToDxsaBinTranslation() {
   TranslateFromMLIRRegistration registration{
       "export-dxsa-bin", "Translate MLIR to DXSA binary",

--- a/mlir/test/Target/DXSA/import_hex.mlir
+++ b/mlir/test/Target/DXSA/import_hex.mlir
@@ -1,0 +1,8 @@
+// RUN: mlir-translate --import-dxsa-hex %s | FileCheck %s
+// RUN: mlir-translate --import-dxsa-hex %s | mlir-opt --verify-roundtrip
+
+// CHECK:      dxsa.module pixel_shader 5 0 {
+0x00000050, 0x00000004,
+// CHECK-NEXT:   dxsa.dcl_temps 4
+0x02000068, 0x00000004
+// CHECK-NEXT: }


### PR DESCRIPTION
Example:
  // RUN: mlir-translate --import-dxsa-hex %s | FileCheck %s
  // RUN: mlir-translate --import-dxsa-hex %s | mlir-opt --verify-roundtrip

  // CHECK:      dxsa.module pixel_shader 5 0 {
  0x00000050, 0x00000004,
  // CHECK-NEXT:   dxsa.dcl_temps 4
  0x02000068, 0x00000004
  // CHECK-NEXT: }