### PR TITLE
[mlir][dxsa] Add div and div_sat instructions

### DIFF
--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSAFPArithOps.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSAFPArithOps.td
@@ -56,4 +56,45 @@ def DXSA_AddSat : DXSA_BinaryOp<"add_sat"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// dxsa.div
+//===----------------------------------------------------------------------===//
+
+def DXSA_Div : DXSA_BinaryOp<"div"> {
+  let summary = "component-wise floating-point divide";
+  let description = [{
+    The `dxsa.div` operation computes the component-wise floating-point
+    quotient `$dst = $lhs / $rhs`.
+
+    Example:
+
+    ```mlir
+    dxsa.div r<0>, r<1>, r<2>
+    dxsa.div r<0>, -r<1>, -|r<2>|
+    dxsa.div r<0, <x, y>>, r<1, <y, z, x, w>>, |r<2, <z, z, z, z>>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.div_sat
+//===----------------------------------------------------------------------===//
+
+def DXSA_DivSat : DXSA_BinaryOp<"div_sat"> {
+  let summary = "component-wise floating-point divide, saturated to [0, 1]";
+  let description = [{
+    The `dxsa.div_sat` operation computes the component-wise floating-point
+    quotient of `$lhs` and `$rhs`, clamps each component of the result to
+    `[0.0, 1.0]`, and writes it to `$dst`.
+
+    Example:
+
+    ```mlir
+    dxsa.div_sat r<0>, r<1>, r<2>
+    dxsa.div_sat r<0>, -r<1>, -|r<2>|
+    dxsa.div_sat r<0, <x, y>>, r<1, <y, z, x, w>>, |r<2, <z, z, z, z>>|
+    ```
+  }];
+}
+
 #endif // MLIR_DIALECT_DXSA_IR_DXSAFPARITHOPS

--- a/mlir/lib/Target/DXSA/BinaryParser.cpp
+++ b/mlir/lib/Target/DXSA/BinaryParser.cpp
@@ -2109,12 +2109,18 @@ public:
 
     unsigned numOperands = instrInfo[opcode].numOperands;
 
+#define SATURABLE_BINARY_OP(OP)                                                \
+  decodeSaturableBinaryOp<dxsa::OP, dxsa::OP##Sat>(                            \
+      beginOffset, instructionLengthInTokens, modifier.saturate,               \
+      modifier.preciseMask, getLocation())
+
     switch (opcode) {
     case D3D10_SB_OPCODE_ADD:
-      return decodeSaturableBinaryOp<dxsa::Add, dxsa::AddSat>(
-          beginOffset, instructionLengthInTokens, modifier.saturate,
-          modifier.preciseMask, getLocation());
+      return SATURABLE_BINARY_OP(Add);
+    case D3D10_SB_OPCODE_DIV:
+      return SATURABLE_BINARY_OP(Div);
     }
+#undef SATURABLE_BINARY_OP
 
     SmallVector<Operand, 8> operands;
     for (unsigned i = 0; i < numOperands; ++i) {

--- a/mlir/test/Target/DXSA/div.mlir
+++ b/mlir/test/Target/DXSA/div.mlir
@@ -1,0 +1,22 @@
+// RUN: mlir-translate --import-dxsa-hex %s | FileCheck %s
+// RUN: mlir-translate --import-dxsa-hex %s | mlir-opt --verify-roundtrip
+
+// Every operand form appears twice in a row, once as div and once as
+// div_sat, so the test asserts both share identical operand decoding and
+// differ only by the saturate modifier.
+
+// CHECK:      dxsa.module {
+
+// CHECK-NEXT:   dxsa.div r<0>, r<1>, r<2>
+0x0700000e, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001, 0x00100e46, 0x00000002,
+// CHECK-NEXT:   dxsa.div_sat r<0>, r<1>, r<2>
+0x0700200e, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001, 0x00100e46, 0x00000002,
+// CHECK-NEXT:   dxsa.div r<0>, r<1>, l(0x3F800000, 0x40000000, 0x40400000, 0x40800000)
+0x0a00000e, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001, 0x00004002, 0x3f800000, 0x40000000, 0x40400000, 0x40800000,
+// CHECK-NEXT:   dxsa.div_sat r<0>, r<1>, l(0x3F800000, 0x40000000, 0x40400000, 0x40800000)
+0x0a00200e, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001, 0x00004002, 0x3f800000, 0x40000000, 0x40400000, 0x40800000,
+// CHECK-NEXT:   dxsa.div r<0>, -r<1>, |r<2>|
+0x0900000e, 0x001000f2, 0x00000000, 0x80100e46, 0x00000041, 0x00000001, 0x80100e46, 0x00000081, 0x00000002,
+// CHECK-NEXT:   dxsa.div_sat r<0>, -r<1>, |r<2>|
+0x0900200e, 0x001000f2, 0x00000000, 0x80100e46, 0x00000041, 0x00000001, 0x80100e46, 0x00000081, 0x00000002
+// CHECK-NEXT: }


### PR DESCRIPTION
Example:
 dxsa.div r<0>, r<1>, r<2>
 dxsa.div_sat r<0>, -r<1>, |r<2>|