### PR TITLE
[mlir][dxsa] Add round_ne, round_ni, round_pi and round_z instructions

### DIFF
--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSAFPArithOps.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSAFPArithOps.td
@@ -230,4 +230,174 @@ def DXSA_Dp4Sat : DXSA_BinaryOp<"dp4_sat"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// dxsa.round_ne
+//===----------------------------------------------------------------------===//
+
+def DXSA_RoundNe : DXSA_UnaryOp<"round_ne"> {
+  let summary =
+      "component-wise floating-point round to integral float, towards nearest even";
+  let description = [{
+    The `dxsa.round_ne` operation performs a component-wise floating-point
+    round of `$src` to an integral float, writing the integral floating-point
+    values to `$dst`. Rounding is towards nearest even.
+
+    Example:
+
+    ```mlir
+    dxsa.round_ne r<0>, r<1>
+    dxsa.round_ne r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.round_ne_sat
+//===----------------------------------------------------------------------===//
+
+def DXSA_RoundNeSat : DXSA_UnaryOp<"round_ne_sat"> {
+  let summary = "component-wise floating-point round to integral float, towards "
+                "nearest even, saturated to [0, 1]";
+  let description = [{
+    The `dxsa.round_ne_sat` operation performs a component-wise floating-point
+    round of `$src` to an integral float, clamps each resulting component to
+    `[0.0, 1.0]`, and writes it to `$dst`. Rounding is towards nearest even.
+
+    Example:
+
+    ```mlir
+    dxsa.round_ne_sat r<0>, r<1>
+    dxsa.round_ne_sat r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.round_ni
+//===----------------------------------------------------------------------===//
+
+def DXSA_RoundNi : DXSA_UnaryOp<"round_ni"> {
+  let summary = "component-wise floating-point round to integral float, towards "
+                "negative infinity";
+  let description = [{
+    The `dxsa.round_ni` operation performs a component-wise floating-point
+    round of `$src` to an integral float, writing the integral floating-point
+    values to `$dst`. Rounding is towards negative infinity (floor).
+
+    Example:
+
+    ```mlir
+    dxsa.round_ni r<0>, r<1>
+    dxsa.round_ni r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.round_ni_sat
+//===----------------------------------------------------------------------===//
+
+def DXSA_RoundNiSat : DXSA_UnaryOp<"round_ni_sat"> {
+  let summary = "component-wise floating-point round to integral float, towards "
+                "negative infinity, saturated to [0, 1]";
+  let description = [{
+    The `dxsa.round_ni_sat` operation performs a component-wise floating-point
+    round of `$src` to an integral float, clamps each resulting component to
+    `[0.0, 1.0]`, and writes it to `$dst`. Rounding is towards negative
+    infinity (floor).
+
+    Example:
+
+    ```mlir
+    dxsa.round_ni_sat r<0>, r<1>
+    dxsa.round_ni_sat r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.round_pi
+//===----------------------------------------------------------------------===//
+
+def DXSA_RoundPi : DXSA_UnaryOp<"round_pi"> {
+  let summary = "component-wise floating-point round to integral float, towards "
+                "positive infinity";
+  let description = [{
+    The `dxsa.round_pi` operation performs a component-wise floating-point
+    round of `$src` to an integral float, writing the integral floating-point
+    values to `$dst`. Rounding is towards positive infinity (ceil).
+
+    Example:
+
+    ```mlir
+    dxsa.round_pi r<0>, r<1>
+    dxsa.round_pi r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.round_pi_sat
+//===----------------------------------------------------------------------===//
+
+def DXSA_RoundPiSat : DXSA_UnaryOp<"round_pi_sat"> {
+  let summary = "component-wise floating-point round to integral float, towards "
+                "positive infinity, saturated to [0, 1]";
+  let description = [{
+    The `dxsa.round_pi_sat` operation performs a component-wise floating-point
+    round of `$src` to an integral float, clamps each resulting component to
+    `[0.0, 1.0]`, and writes it to `$dst`. Rounding is towards positive
+    infinity (ceil).
+
+    Example:
+
+    ```mlir
+    dxsa.round_pi_sat r<0>, r<1>
+    dxsa.round_pi_sat r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.round_z
+//===----------------------------------------------------------------------===//
+
+def DXSA_RoundZ : DXSA_UnaryOp<"round_z"> {
+  let summary =
+      "component-wise floating-point round to integral float, towards zero";
+  let description = [{
+    The `dxsa.round_z` operation performs a component-wise floating-point
+    round of `$src` to an integral float, writing the integral floating-point
+    values to `$dst`. Rounding is towards zero.
+
+    Example:
+
+    ```mlir
+    dxsa.round_z r<0>, r<1>
+    dxsa.round_z r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.round_z_sat
+//===----------------------------------------------------------------------===//
+
+def DXSA_RoundZSat : DXSA_UnaryOp<"round_z_sat"> {
+  let summary = "component-wise floating-point round to integral float, towards "
+                "zero, saturated to [0, 1]";
+  let description = [{
+    The `dxsa.round_z_sat` operation performs a component-wise floating-point
+    round of `$src` to an integral float, clamps each resulting component to
+    `[0.0, 1.0]`, and writes it to `$dst`. Rounding is towards zero.
+
+    Example:
+
+    ```mlir
+    dxsa.round_z_sat r<0>, r<1>
+    dxsa.round_z_sat r<0>, -|r<1>|
+    ```
+  }];
+}
+
 #endif // MLIR_DIALECT_DXSA_IR_DXSAFPARITHOPS

--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSAOpBase.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSAOpBase.td
@@ -28,6 +28,16 @@ class DXSA_Op<string mnemonic, list<Trait> traits = []> :
 // DXSA shared bases for ops with inline operands
 //===----------------------------------------------------------------------===//
 
+class DXSA_UnaryOp<string mnemonic> : DXSA_Op<mnemonic> {
+  let arguments = (ins
+      DXSA_DstOperandAttr:$dst,
+      DXSA_SrcOperandAttr:$src,
+      OptionalAttr<DXSA_ComponentMaskAttr>:$precise);
+  let results = (outs);
+  let assemblyFormat =
+      "(`precise` $precise^)? $dst `,` $src attr-dict";
+}
+
 class DXSA_BinaryOp<string mnemonic> : DXSA_Op<mnemonic> {
   let arguments = (ins
       DXSA_DstOperandAttr:$dst,

--- a/mlir/lib/Target/DXSA/BinaryParser.cpp
+++ b/mlir/lib/Target/DXSA/BinaryParser.cpp
@@ -787,6 +787,17 @@ public:
   }
 
   template <typename OpT>
+  Instruction buildUnaryOp(dxsa::DstOperandAttr dst, dxsa::SrcOperandAttr src,
+                           uint32_t preciseMask, Location loc) {
+    auto preciseAttr =
+        preciseMask
+            ? dxsa::ComponentMaskAttr::get(
+                  context, static_cast<dxsa::ComponentMask>(preciseMask))
+            : dxsa::ComponentMaskAttr();
+    return OpT::create(builder, loc, dst, src, preciseAttr);
+  }
+
+  template <typename OpT>
   Instruction buildBinaryOp(dxsa::DstOperandAttr dst, dxsa::SrcOperandAttr lhs,
                             dxsa::SrcOperandAttr rhs, uint32_t preciseMask,
                             Location loc) {
@@ -1649,6 +1660,21 @@ public:
                                        fields->values, fields->values64);
   }
 
+  template <typename UnOpT, typename UnOpSatT>
+  FailureOr<Instruction>
+  decodeSaturableUnaryOp(size_t beginOffset, uint32_t length, bool saturate,
+                         uint32_t preciseMask, Location loc) {
+    auto dst = parseDstOperand();
+    FAILURE_IF_FAILED(dst);
+    auto src = parseSrcOperand();
+    FAILURE_IF_FAILED(src);
+    if (failed(verifyInstructionLength(beginOffset, length)))
+      return failure();
+    if (saturate)
+      return builder.buildUnaryOp<UnOpSatT>(*dst, *src, preciseMask, loc);
+    return builder.buildUnaryOp<UnOpT>(*dst, *src, preciseMask, loc);
+  }
+
   template <typename BinOpT, typename BinOpSatT>
   FailureOr<Instruction>
   decodeSaturableBinaryOp(size_t beginOffset, uint32_t length, bool saturate,
@@ -2155,6 +2181,11 @@ public:
       beginOffset, instructionLengthInTokens, modifier.saturate,               \
       modifier.preciseMask, getLocation())
 
+#define SATURABLE_UNARY_OP(OP)                                                 \
+  decodeSaturableUnaryOp<dxsa::OP, dxsa::OP##Sat>(                             \
+      beginOffset, instructionLengthInTokens, modifier.saturate,               \
+      modifier.preciseMask, getLocation())
+
     switch (opcode) {
     case D3D10_SB_OPCODE_ADD:
       return SATURABLE_BINARY_OP(Add);
@@ -2166,8 +2197,17 @@ public:
       return SATURABLE_BINARY_OP(Dp3);
     case D3D10_SB_OPCODE_DP4:
       return SATURABLE_BINARY_OP(Dp4);
+    case D3D10_SB_OPCODE_ROUND_NE:
+      return SATURABLE_UNARY_OP(RoundNe);
+    case D3D10_SB_OPCODE_ROUND_NI:
+      return SATURABLE_UNARY_OP(RoundNi);
+    case D3D10_SB_OPCODE_ROUND_PI:
+      return SATURABLE_UNARY_OP(RoundPi);
+    case D3D10_SB_OPCODE_ROUND_Z:
+      return SATURABLE_UNARY_OP(RoundZ);
     }
 #undef SATURABLE_BINARY_OP
+#undef SATURABLE_UNARY_OP
 
     SmallVector<Operand, 8> operands;
     for (unsigned i = 0; i < numOperands; ++i) {

--- a/mlir/test/Target/DXSA/round.mlir
+++ b/mlir/test/Target/DXSA/round.mlir
@@ -1,0 +1,90 @@
+// RUN: mlir-translate --import-dxsa-hex %s | FileCheck %s
+// RUN: mlir-translate --import-dxsa-hex %s | mlir-opt --verify-roundtrip
+
+// CHECK:      dxsa.module {
+
+// CHECK-NEXT:   dxsa.round_ne r<0>, r<1>
+0x05000040, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ne r<0>, -r<1>
+0x06000040, 0x001000f2, 0x00000000, 0x80100e46, 0x00000041, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ne r<0>, |r<1>|
+0x06000040, 0x001000f2, 0x00000000, 0x80100e46, 0x00000081, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ne r<0>, -|r<1>|
+0x06000040, 0x001000f2, 0x00000000, 0x80100e46, 0x000000c1, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ne precise <x, y> r<0>, r<1>
+0x05180040, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ne_sat r<0>, r<1>
+0x05002040, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ne_sat precise <x> r<0>, r<1>
+0x05082040, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ni r<0>, r<1>
+0x05000041, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ni r<0>, -r<1>
+0x06000041, 0x001000f2, 0x00000000, 0x80100e46, 0x00000041, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ni r<0>, |r<1>|
+0x06000041, 0x001000f2, 0x00000000, 0x80100e46, 0x00000081, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ni r<0>, -|r<1>|
+0x06000041, 0x001000f2, 0x00000000, 0x80100e46, 0x000000c1, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ni precise <x, y> r<0>, r<1>
+0x05180041, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ni_sat r<0>, r<1>
+0x05002041, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_ni_sat precise <x> r<0>, r<1>
+0x05082041, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_pi r<0>, r<1>
+0x05000042, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_pi r<0>, -r<1>
+0x06000042, 0x001000f2, 0x00000000, 0x80100e46, 0x00000041, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_pi r<0>, |r<1>|
+0x06000042, 0x001000f2, 0x00000000, 0x80100e46, 0x00000081, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_pi r<0>, -|r<1>|
+0x06000042, 0x001000f2, 0x00000000, 0x80100e46, 0x000000c1, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_pi precise <x, y> r<0>, r<1>
+0x05180042, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_pi_sat r<0>, r<1>
+0x05002042, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_pi_sat precise <x> r<0>, r<1>
+0x05082042, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_z r<0>, r<1>
+0x05000043, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_z r<0>, -r<1>
+0x06000043, 0x001000f2, 0x00000000, 0x80100e46, 0x00000041, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_z r<0>, |r<1>|
+0x06000043, 0x001000f2, 0x00000000, 0x80100e46, 0x00000081, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_z r<0>, -|r<1>|
+0x06000043, 0x001000f2, 0x00000000, 0x80100e46, 0x000000c1, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_z precise <x, y> r<0>, r<1>
+0x05180043, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_z_sat r<0>, r<1>
+0x05002043, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.round_z_sat precise <x> r<0>, r<1>
+0x05082043, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT: }


### PR DESCRIPTION
Example:
 dxsa.round_ne r<0>, r<1>
 dxsa.round_z_sat r<0>, -|r<1>|