### PR TITLE
[mlir][dxsa] Add exp, frc, log, rcp, rsq and sqrt instructions

### DIFF
--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSAFPArithOps.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSAFPArithOps.td
@@ -231,6 +231,164 @@ def DXSA_Dp4Sat : DXSA_BinaryOp<"dp4_sat"> {
 }
 
 //===----------------------------------------------------------------------===//
+// dxsa.exp
+//===----------------------------------------------------------------------===//
+
+def DXSA_Exp : DXSA_UnaryOp<"exp"> {
+  let summary = "component-wise base-2 exponential";
+  let description = [{
+    The `dxsa.exp` operation computes the component-wise base-2 exponential
+    `$dst = 2 ^ $src`.
+
+    Example:
+
+    ```mlir
+    dxsa.exp r<0>, r<1>
+    dxsa.exp r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.exp_sat
+//===----------------------------------------------------------------------===//
+
+def DXSA_ExpSat : DXSA_UnaryOp<"exp_sat"> {
+  let summary = "component-wise base-2 exponential, saturated to [0, 1]";
+  let description = [{
+    The `dxsa.exp_sat` operation computes the component-wise base-2
+    exponential of `$src`, clamps each component of the result to
+    `[0.0, 1.0]`, and writes it to `$dst`.
+
+    Example:
+
+    ```mlir
+    dxsa.exp_sat r<0>, r<1>
+    dxsa.exp_sat r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.frc
+//===----------------------------------------------------------------------===//
+
+def DXSA_Frc : DXSA_UnaryOp<"frc"> {
+  let summary = "component-wise fractional part";
+  let description = [{
+    The `dxsa.frc` operation extracts the component-wise fractional part of
+    `$src` and writes it to `$dst`. The fractional part is `$src` minus its
+    floor - `$dst` = `$rhs` - round_ni(`$lhs`), so every result component
+    lies in `[0.0, 1.0)`.
+
+    Example:
+
+    ```mlir
+    dxsa.frc r<0>, r<1>
+    dxsa.frc r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.frc_sat
+//===----------------------------------------------------------------------===//
+
+def DXSA_FrcSat : DXSA_UnaryOp<"frc_sat"> {
+  let summary = "component-wise fractional part, saturated to [0, 1]";
+  let description = [{
+    The `dxsa.frc_sat` operation extracts the component-wise fractional part
+    of `$src`, clamps each component of the result to `[0.0, 1.0]`, and
+    writes it to `$dst`.
+
+    Example:
+
+    ```mlir
+    dxsa.frc_sat r<0>, r<1>
+    dxsa.frc_sat r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.log
+//===----------------------------------------------------------------------===//
+
+def DXSA_Log : DXSA_UnaryOp<"log"> {
+  let summary = "component-wise base-2 logarithm";
+  let description = [{
+    The `dxsa.log` operation computes the component-wise base-2 logarithm
+    `$dst = log2($src)`.
+
+    Example:
+
+    ```mlir
+    dxsa.log r<0>, r<1>
+    dxsa.log r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.log_sat
+//===----------------------------------------------------------------------===//
+
+def DXSA_LogSat : DXSA_UnaryOp<"log_sat"> {
+  let summary = "component-wise base-2 logarithm, saturated to [0, 1]";
+  let description = [{
+    The `dxsa.log_sat` operation computes the component-wise base-2 logarithm
+    of `$src`, clamps each component of the result to `[0.0, 1.0]`, and
+    writes it to `$dst`.
+
+    Example:
+
+    ```mlir
+    dxsa.log_sat r<0>, r<1>
+    dxsa.log_sat r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.rcp
+//===----------------------------------------------------------------------===//
+
+def DXSA_Rcp : DXSA_UnaryOp<"rcp"> {
+  let summary = "component-wise reciprocal";
+  let description = [{
+    The `dxsa.rcp` operation computes the component-wise reciprocal
+    `$dst = 1.0 / $src`.
+
+    Example:
+
+    ```mlir
+    dxsa.rcp r<0>, r<1>
+    dxsa.rcp r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.rcp_sat
+//===----------------------------------------------------------------------===//
+
+def DXSA_RcpSat : DXSA_UnaryOp<"rcp_sat"> {
+  let summary = "component-wise reciprocal, saturated to [0, 1]";
+  let description = [{
+    The `dxsa.rcp_sat` operation computes the component-wise reciprocal of
+    `$src`, clamps each component of the result to `[0.0, 1.0]`, and writes
+    it to `$dst`.
+
+    Example:
+
+    ```mlir
+    dxsa.rcp_sat r<0>, r<1>
+    dxsa.rcp_sat r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // dxsa.round_ne
 //===----------------------------------------------------------------------===//
 
@@ -396,6 +554,84 @@ def DXSA_RoundZSat : DXSA_UnaryOp<"round_z_sat"> {
     ```mlir
     dxsa.round_z_sat r<0>, r<1>
     dxsa.round_z_sat r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.rsq
+//===----------------------------------------------------------------------===//
+
+def DXSA_Rsq : DXSA_UnaryOp<"rsq"> {
+  let summary = "component-wise reciprocal square root";
+  let description = [{
+    The `dxsa.rsq` operation computes the component-wise reciprocal square
+    root `$dst = 1.0 / sqrt($src)`.
+
+    Example:
+
+    ```mlir
+    dxsa.rsq r<0>, r<1>
+    dxsa.rsq r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.rsq_sat
+//===----------------------------------------------------------------------===//
+
+def DXSA_RsqSat : DXSA_UnaryOp<"rsq_sat"> {
+  let summary = "component-wise reciprocal square root, saturated to [0, 1]";
+  let description = [{
+    The `dxsa.rsq_sat` operation computes the component-wise reciprocal
+    square root of `$src`, clamps each component of the result to
+    `[0.0, 1.0]`, and writes it to `$dst`.
+
+    Example:
+
+    ```mlir
+    dxsa.rsq_sat r<0>, r<1>
+    dxsa.rsq_sat r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.sqrt
+//===----------------------------------------------------------------------===//
+
+def DXSA_Sqrt : DXSA_UnaryOp<"sqrt"> {
+  let summary = "component-wise square root";
+  let description = [{
+    The `dxsa.sqrt` operation computes the component-wise square root
+    `$dst = sqrt($src)`.
+
+    Example:
+
+    ```mlir
+    dxsa.sqrt r<0>, r<1>
+    dxsa.sqrt r<0>, -|r<1>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.sqrt_sat
+//===----------------------------------------------------------------------===//
+
+def DXSA_SqrtSat : DXSA_UnaryOp<"sqrt_sat"> {
+  let summary = "component-wise square root, saturated to [0, 1]";
+  let description = [{
+    The `dxsa.sqrt_sat` operation computes the component-wise square root of
+    `$src`, clamps each component of the result to `[0.0, 1.0]`, and writes
+    it to `$dst`.
+
+    Example:
+
+    ```mlir
+    dxsa.sqrt_sat r<0>, r<1>
+    dxsa.sqrt_sat r<0>, -|r<1>|
     ```
   }];
 }

--- a/mlir/lib/Target/DXSA/BinaryParser.cpp
+++ b/mlir/lib/Target/DXSA/BinaryParser.cpp
@@ -2205,6 +2205,14 @@ public:
       return SATURABLE_BINARY_OP(Dp3);
     case D3D10_SB_OPCODE_DP4:
       return SATURABLE_BINARY_OP(Dp4);
+    case D3D10_SB_OPCODE_EXP:
+      return SATURABLE_UNARY_OP(Exp);
+    case D3D10_SB_OPCODE_FRC:
+      return SATURABLE_UNARY_OP(Frc);
+    case D3D10_SB_OPCODE_LOG:
+      return SATURABLE_UNARY_OP(Log);
+    case D3D11_SB_OPCODE_RCP:
+      return SATURABLE_UNARY_OP(Rcp);
     case D3D10_SB_OPCODE_ROUND_NE:
       return SATURABLE_UNARY_OP(RoundNe);
     case D3D10_SB_OPCODE_ROUND_NI:
@@ -2213,6 +2221,10 @@ public:
       return SATURABLE_UNARY_OP(RoundPi);
     case D3D10_SB_OPCODE_ROUND_Z:
       return SATURABLE_UNARY_OP(RoundZ);
+    case D3D10_SB_OPCODE_RSQ:
+      return SATURABLE_UNARY_OP(Rsq);
+    case D3D10_SB_OPCODE_SQRT:
+      return SATURABLE_UNARY_OP(Sqrt);
     case D3D10_SB_OPCODE_EQ:
       return BINARY_OP(Eq);
     case D3D10_SB_OPCODE_GE:

--- a/mlir/test/Target/DXSA/exp.mlir
+++ b/mlir/test/Target/DXSA/exp.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-translate --import-dxsa-hex %s | FileCheck %s
+// RUN: mlir-translate --import-dxsa-hex %s | mlir-opt --verify-roundtrip
+
+// CHECK:      dxsa.module {
+
+// CHECK-NEXT:   dxsa.exp r<0>, r<1>
+0x05000019, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.exp r<0>, -r<1>
+0x06000019, 0x001000f2, 0x00000000, 0x80100e46, 0x00000041, 0x00000001
+
+// CHECK-NEXT:   dxsa.exp r<0>, |r<1>|
+0x06000019, 0x001000f2, 0x00000000, 0x80100e46, 0x00000081, 0x00000001
+
+// CHECK-NEXT:   dxsa.exp r<0>, -|r<1>|
+0x06000019, 0x001000f2, 0x00000000, 0x80100e46, 0x000000c1, 0x00000001
+
+// CHECK-NEXT:   dxsa.exp r<0, <x>>, r<1, <y, z, w, y>>
+0x05000019, 0x00100012, 0x00000000, 0x00100796, 0x00000001
+
+// CHECK-NEXT:   dxsa.exp precise <x, y> r<0>, r<1>
+0x05180019, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.exp_sat r<0>, r<1>
+0x05002019, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT: }

--- a/mlir/test/Target/DXSA/frc.mlir
+++ b/mlir/test/Target/DXSA/frc.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-translate --import-dxsa-hex %s | FileCheck %s
+// RUN: mlir-translate --import-dxsa-hex %s | mlir-opt --verify-roundtrip
+
+// CHECK:      dxsa.module {
+
+// CHECK-NEXT:   dxsa.frc r<0>, r<1>
+0x0500001a, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.frc r<0>, -r<1>
+0x0600001a, 0x001000f2, 0x00000000, 0x80100e46, 0x00000041, 0x00000001
+
+// CHECK-NEXT:   dxsa.frc r<0>, |r<1>|
+0x0600001a, 0x001000f2, 0x00000000, 0x80100e46, 0x00000081, 0x00000001
+
+// CHECK-NEXT:   dxsa.frc r<0>, -|r<1>|
+0x0600001a, 0x001000f2, 0x00000000, 0x80100e46, 0x000000c1, 0x00000001
+
+// CHECK-NEXT:   dxsa.frc r<0, <x>>, r<1, <y, z, w, y>>
+0x0500001a, 0x00100012, 0x00000000, 0x00100796, 0x00000001
+
+// CHECK-NEXT:   dxsa.frc precise <x, y> r<0>, r<1>
+0x0518001a, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.frc_sat r<0>, r<1>
+0x0500201a, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT: }

--- a/mlir/test/Target/DXSA/log.mlir
+++ b/mlir/test/Target/DXSA/log.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-translate --import-dxsa-hex %s | FileCheck %s
+// RUN: mlir-translate --import-dxsa-hex %s | mlir-opt --verify-roundtrip
+
+// CHECK:      dxsa.module {
+
+// CHECK-NEXT:   dxsa.log r<0>, r<1>
+0x0500002f, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.log r<0>, -r<1>
+0x0600002f, 0x001000f2, 0x00000000, 0x80100e46, 0x00000041, 0x00000001
+
+// CHECK-NEXT:   dxsa.log r<0>, |r<1>|
+0x0600002f, 0x001000f2, 0x00000000, 0x80100e46, 0x00000081, 0x00000001
+
+// CHECK-NEXT:   dxsa.log r<0>, -|r<1>|
+0x0600002f, 0x001000f2, 0x00000000, 0x80100e46, 0x000000c1, 0x00000001
+
+// CHECK-NEXT:   dxsa.log r<0, <x>>, r<1, <y, z, w, y>>
+0x0500002f, 0x00100012, 0x00000000, 0x00100796, 0x00000001
+
+// CHECK-NEXT:   dxsa.log precise <x, y> r<0>, r<1>
+0x0518002f, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.log_sat r<0>, r<1>
+0x0500202f, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT: }

--- a/mlir/test/Target/DXSA/rcp.mlir
+++ b/mlir/test/Target/DXSA/rcp.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-translate --import-dxsa-hex %s | FileCheck %s
+// RUN: mlir-translate --import-dxsa-hex %s | mlir-opt --verify-roundtrip
+
+// CHECK:      dxsa.module {
+
+// CHECK-NEXT:   dxsa.rcp r<0>, r<1>
+0x05000081, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.rcp r<0>, -r<1>
+0x06000081, 0x001000f2, 0x00000000, 0x80100e46, 0x00000041, 0x00000001
+
+// CHECK-NEXT:   dxsa.rcp r<0>, |r<1>|
+0x06000081, 0x001000f2, 0x00000000, 0x80100e46, 0x00000081, 0x00000001
+
+// CHECK-NEXT:   dxsa.rcp r<0>, -|r<1>|
+0x06000081, 0x001000f2, 0x00000000, 0x80100e46, 0x000000c1, 0x00000001
+
+// CHECK-NEXT:   dxsa.rcp r<0, <x>>, r<1, <y, z, w, y>>
+0x05000081, 0x00100012, 0x00000000, 0x00100796, 0x00000001
+
+// CHECK-NEXT:   dxsa.rcp precise <x, y> r<0>, r<1>
+0x05180081, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.rcp_sat r<0>, r<1>
+0x05002081, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT: }

--- a/mlir/test/Target/DXSA/rsq.mlir
+++ b/mlir/test/Target/DXSA/rsq.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-translate --import-dxsa-hex %s | FileCheck %s
+// RUN: mlir-translate --import-dxsa-hex %s | mlir-opt --verify-roundtrip
+
+// CHECK:      dxsa.module {
+
+// CHECK-NEXT:   dxsa.rsq r<0>, r<1>
+0x05000044, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.rsq r<0>, -r<1>
+0x06000044, 0x001000f2, 0x00000000, 0x80100e46, 0x00000041, 0x00000001
+
+// CHECK-NEXT:   dxsa.rsq r<0>, |r<1>|
+0x06000044, 0x001000f2, 0x00000000, 0x80100e46, 0x00000081, 0x00000001
+
+// CHECK-NEXT:   dxsa.rsq r<0>, -|r<1>|
+0x06000044, 0x001000f2, 0x00000000, 0x80100e46, 0x000000c1, 0x00000001
+
+// CHECK-NEXT:   dxsa.rsq r<0, <x>>, r<1, <y, z, w, y>>
+0x05000044, 0x00100012, 0x00000000, 0x00100796, 0x00000001
+
+// CHECK-NEXT:   dxsa.rsq precise <x, y> r<0>, r<1>
+0x05180044, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.rsq_sat r<0>, r<1>
+0x05002044, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT: }

--- a/mlir/test/Target/DXSA/sqrt.mlir
+++ b/mlir/test/Target/DXSA/sqrt.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-translate --import-dxsa-hex %s | FileCheck %s
+// RUN: mlir-translate --import-dxsa-hex %s | mlir-opt --verify-roundtrip
+
+// CHECK:      dxsa.module {
+
+// CHECK-NEXT:   dxsa.sqrt r<0>, r<1>
+0x0500004b, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.sqrt r<0>, -r<1>
+0x0600004b, 0x001000f2, 0x00000000, 0x80100e46, 0x00000041, 0x00000001
+
+// CHECK-NEXT:   dxsa.sqrt r<0>, |r<1>|
+0x0600004b, 0x001000f2, 0x00000000, 0x80100e46, 0x00000081, 0x00000001
+
+// CHECK-NEXT:   dxsa.sqrt r<0>, -|r<1>|
+0x0600004b, 0x001000f2, 0x00000000, 0x80100e46, 0x000000c1, 0x00000001
+
+// CHECK-NEXT:   dxsa.sqrt r<0, <x>>, r<1, <y, z, w, y>>
+0x0500004b, 0x00100012, 0x00000000, 0x00100796, 0x00000001
+
+// CHECK-NEXT:   dxsa.sqrt precise <x, y> r<0>, r<1>
+0x0518004b, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT:   dxsa.sqrt_sat r<0>, r<1>
+0x0500204b, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// CHECK-NEXT: }


### PR DESCRIPTION
Example:
 dxsa.exp r<0>, r<1>
 dxsa.sqrt_sat r<0>, -|r<1>|