### PR TITLE
[mlir][dxsa] Add imm_atomic_alloc and imm_atomic_consume instructions

### DIFF
--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSAAtomicOps.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSAAtomicOps.td
@@ -505,4 +505,65 @@ def DXSA_ImmAtomicCmpExch : DXSA_Op<"imm_atomic_cmp_exch"> {
       "$dst0 `,` $dst1 `,` $dst_address `,` $src0 `,` $src1 attr-dict";
 }
 
+//===----------------------------------------------------------------------===//
+// DXSA shared base for UnorderedAccessView (UAV) counter atomics
+//===----------------------------------------------------------------------===//
+
+class DXSA_ImmAtomicCounterOp<string mnemonic> : DXSA_Op<mnemonic> {
+  let arguments = (ins
+      DXSA_DstOperandAttr:$dst,
+      DXSA_SrcOperandAttr:$uav);
+  let results = (outs);
+  let assemblyFormat = "$dst `,` $uav attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.imm_atomic_alloc
+//===----------------------------------------------------------------------===//
+
+def DXSA_ImmAtomicAlloc : DXSA_ImmAtomicCounterOp<"imm_atomic_alloc"> {
+  let summary =
+      "atomic increment of an UnorderedAccessView (UAV) counter, returning the "
+      "prior value";
+  let description = [{
+    The `dxsa.imm_atomic_alloc` operation atomically increments the hidden
+    32-bit counter of the append or count UnorderedAccessView (UAV)
+    `$uav` and writes the value the counter held before the increment
+    into `$dst`.
+
+    `$uav` must be a structured buffer UAV declared with a counter. The
+    counter wraps on overflow.
+
+    Example:
+
+    ```mlir
+    dxsa.imm_atomic_alloc r<0, <x>>, u<0>
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.imm_atomic_consume
+//===----------------------------------------------------------------------===//
+
+def DXSA_ImmAtomicConsume : DXSA_ImmAtomicCounterOp<"imm_atomic_consume"> {
+  let summary =
+      "atomic decrement of an UnorderedAccessView (UAV) counter, returning the "
+      "new value";
+  let description = [{
+    The `dxsa.imm_atomic_consume` operation atomically decrements the hidden
+    32-bit counter of the append or count UnorderedAccessView (UAV)
+    `$uav` and writes the new (post-decrement) value into `$dst`.
+
+    `$uav` must be a structured buffer UAV declared with a counter. The
+    counter wraps on underflow.
+
+    Example:
+
+    ```mlir
+    dxsa.imm_atomic_consume r<0, <x>>, u<0>
+    ```
+  }];
+}
+
 #endif // MLIR_DIALECT_DXSA_IR_DXSAATOMICOPS

--- a/mlir/lib/Target/DXSA/BinaryParser.cpp
+++ b/mlir/lib/Target/DXSA/BinaryParser.cpp
@@ -2473,6 +2473,10 @@ public:
       return PLAIN_OP(ImmAtomicUMax, 2, 2, HasPreciseAttr::No);
     case D3D11_SB_OPCODE_IMM_ATOMIC_UMIN:
       return PLAIN_OP(ImmAtomicUMin, 2, 2, HasPreciseAttr::No);
+    case D3D11_SB_OPCODE_IMM_ATOMIC_ALLOC:
+      return PLAIN_OP(ImmAtomicAlloc, 1, 1, HasPreciseAttr::No);
+    case D3D11_SB_OPCODE_IMM_ATOMIC_CONSUME:
+      return PLAIN_OP(ImmAtomicConsume, 1, 1, HasPreciseAttr::No);
     }
 #undef SATURABLE_OP
 #undef PLAIN_OP

--- a/mlir/test/Target/DXSA/atomic_ops.test
+++ b/mlir/test/Target/DXSA/atomic_ops.test
@@ -187,3 +187,17 @@
 // CHECK-NEXT:   dxsa.imm_atomic_exch r<0, <x>>, u<0>, r<1>, r<2>
 // CHECK-NEXT: }
 0x090000b8, 0x00100012, 0x00000000, 0x0011e000, 0x00000000, 0x00100e46, 0x00000001, 0x00100e46, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.imm_atomic_alloc r<0, <x>>, u<0>
+// CHECK-NEXT: }
+0x050000b2, 0x00100012, 0x00000000, 0x0011e000, 0x00000000
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.imm_atomic_consume r<0, <x>>, u<0>
+// CHECK-NEXT: }
+0x050000b3, 0x00100012, 0x00000000, 0x0011e000, 0x00000000


### PR DESCRIPTION
Example:
  dxsa.imm_atomic_alloc r<0, <x>>, u<0>
  dxsa.imm_atomic_consume r<0, <x>>, u<0>