### PR TITLE
[mlir][dxsa] Add deq, dge, dlt and dne instructions

### DIFF
--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSAConditionOps.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSAConditionOps.td
@@ -217,4 +217,84 @@ def DXSA_Ult : DXSA_BinaryOp<"ult"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// dxsa.deq
+//===----------------------------------------------------------------------===//
+
+def DXSA_Deq : DXSA_BinaryOp<"deq"> {
+  let summary = "component-wise double-precision equality comparison";
+  let description = [{
+    The `dxsa.deq` operation computes the component-wise double-precision
+    floating-point comparison `$lhs == $rhs`, writing 0xFFFFFFFF to a
+    component of `$dst` when the result is true and 0 when it is false.
+
+    Example:
+
+    ```mlir
+    dxsa.deq r<0>, r<1>, r<2>
+    dxsa.deq r<0>, -r<1>, |r<2>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.dge
+//===----------------------------------------------------------------------===//
+
+def DXSA_Dge : DXSA_BinaryOp<"dge"> {
+  let summary = "component-wise double-precision greater-equal comparison";
+  let description = [{
+    The `dxsa.dge` operation computes the component-wise double-precision
+    floating-point comparison `$lhs >= $rhs`, writing 0xFFFFFFFF to a
+    component of `$dst` when the result is true and 0 when it is false.
+
+    Example:
+
+    ```mlir
+    dxsa.dge r<0>, r<1>, r<2>
+    dxsa.dge r<0>, -r<1>, |r<2>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.dlt
+//===----------------------------------------------------------------------===//
+
+def DXSA_Dlt : DXSA_BinaryOp<"dlt"> {
+  let summary = "component-wise double-precision less-than comparison";
+  let description = [{
+    The `dxsa.dlt` operation computes the component-wise double-precision
+    floating-point comparison `$lhs < $rhs`, writing 0xFFFFFFFF to a
+    component of `$dst` when the result is true and 0 when it is false.
+
+    Example:
+
+    ```mlir
+    dxsa.dlt r<0>, r<1>, r<2>
+    dxsa.dlt r<0>, -r<1>, |r<2>|
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.dne
+//===----------------------------------------------------------------------===//
+
+def DXSA_Dne : DXSA_BinaryOp<"dne"> {
+  let summary = "component-wise double-precision not-equal comparison";
+  let description = [{
+    The `dxsa.dne` operation computes the component-wise double-precision
+    floating-point comparison `$lhs != $rhs`, writing 0xFFFFFFFF to a
+    component of `$dst` when the result is true and 0 when it is false.
+
+    Example:
+
+    ```mlir
+    dxsa.dne r<0>, r<1>, r<2>
+    dxsa.dne r<0>, -r<1>, |r<2>|
+    ```
+  }];
+}
+
 #endif // MLIR_DIALECT_DXSA_IR_DXSACONDITIONOPS

--- a/mlir/lib/Target/DXSA/BinaryParser.cpp
+++ b/mlir/lib/Target/DXSA/BinaryParser.cpp
@@ -2440,6 +2440,14 @@ public:
       return PLAIN_OP(Uge, 1, 2, HasPreciseAttr::Yes);
     case D3D10_SB_OPCODE_ULT:
       return PLAIN_OP(Ult, 1, 2, HasPreciseAttr::Yes);
+    case D3D11_SB_OPCODE_DEQ:
+      return PLAIN_OP(Deq, 1, 2, HasPreciseAttr::Yes);
+    case D3D11_SB_OPCODE_DGE:
+      return PLAIN_OP(Dge, 1, 2, HasPreciseAttr::Yes);
+    case D3D11_SB_OPCODE_DLT:
+      return PLAIN_OP(Dlt, 1, 2, HasPreciseAttr::Yes);
+    case D3D11_SB_OPCODE_DNE:
+      return PLAIN_OP(Dne, 1, 2, HasPreciseAttr::Yes);
     // Integer arithmetic instructions
     case D3D10_SB_OPCODE_IADD:
       return PLAIN_OP(IAdd, 1, 2, HasPreciseAttr::Yes);

--- a/mlir/test/Target/DXSA/condition_ops.test
+++ b/mlir/test/Target/DXSA/condition_ops.test
@@ -1,0 +1,56 @@
+// RUN: mlir-translate --split-input-file --import-dxsa-hex %s | FileCheck %s
+// RUN: mlir-translate --split-input-file --import-dxsa-hex %s | mlir-opt --split-input-file --verify-roundtrip
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.deq r<0, <x, y>>, -r<1, <z, w, x, y>>, -|r<2, <x, y, x, y>>|
+// CHECK-NEXT: }
+0x090000c3, 0x00100032, 0x00000000, 0x801004e6, 0x00000041, 0x00000001, 0x80100446, 0x000000c1, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.deq precise <x, y> r<0, <x, y>>, r<1>, |r<2>|
+// CHECK-NEXT: }
+0x081800c3, 0x00100032, 0x00000000, 0x00100e46, 0x00000001, 0x80100e46, 0x00000081, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.dge r<0, <x, y>>, -r<1, <z, w, x, y>>, -|r<2, <x, y, x, y>>|
+// CHECK-NEXT: }
+0x090000c4, 0x00100032, 0x00000000, 0x801004e6, 0x00000041, 0x00000001, 0x80100446, 0x000000c1, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.dge precise <x, y> r<0, <x, y>>, r<1>, |r<2>|
+// CHECK-NEXT: }
+0x081800c4, 0x00100032, 0x00000000, 0x00100e46, 0x00000001, 0x80100e46, 0x00000081, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.dlt r<0, <x, y>>, -r<1, <z, w, x, y>>, -|r<2, <x, y, x, y>>|
+// CHECK-NEXT: }
+0x090000c5, 0x00100032, 0x00000000, 0x801004e6, 0x00000041, 0x00000001, 0x80100446, 0x000000c1, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.dlt precise <x, y> r<0, <x, y>>, r<1>, |r<2>|
+// CHECK-NEXT: }
+0x081800c5, 0x00100032, 0x00000000, 0x00100e46, 0x00000001, 0x80100e46, 0x00000081, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.dne r<0, <x, y>>, -r<1, <z, w, x, y>>, -|r<2, <x, y, x, y>>|
+// CHECK-NEXT: }
+0x090000c6, 0x00100032, 0x00000000, 0x801004e6, 0x00000041, 0x00000001, 0x80100446, 0x000000c1, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.dne precise <x, y> r<0, <x, y>>, r<1>, |r<2>|
+// CHECK-NEXT: }
+0x081800c6, 0x00100032, 0x00000000, 0x00100e46, 0x00000001, 0x80100e46, 0x00000081, 0x00000002


### PR DESCRIPTION
Example:
 dxsa.deq r<0>, r<1>, r<2>
 dxsa.dge r<0>, r<1>, r<2>
 dxsa.dlt r<0>, r<1>, r<2>
 dxsa.dne r<0>, r<1>, r<2>