### PR TITLE
Add imad, imul, msad instructions

### DIFF
--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSAFPArithOps.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSAFPArithOps.td
@@ -353,19 +353,6 @@ def DXSA_LogSat : DXSA_UnaryOp<"log_sat"> {
 // dxsa.mad
 //===----------------------------------------------------------------------===//
 
-// Shared base for the multiply-add family: `$dst = $lhs * $rhs + $acc`.
-class DXSA_MultiplyAddOp<string mnemonic> : DXSA_Op<mnemonic> {
-  let arguments = (ins
-      DXSA_DstOperandAttr:$dst,
-      DXSA_SrcOperandAttr:$lhs,
-      DXSA_SrcOperandAttr:$rhs,
-      DXSA_SrcOperandAttr:$acc,
-      OptionalAttr<DXSA_ComponentMaskAttr>:$precise);
-  let results = (outs);
-  let assemblyFormat =
-      "(`precise` $precise^)? $dst `,` $lhs `,` $rhs `,` $acc attr-dict";
-}
-
 def DXSA_Mad : DXSA_MultiplyAddOp<"mad"> {
   let summary = "component-wise floating-point multiply-add";
   let description = [{

--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSAIntArithOps.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSAIntArithOps.td
@@ -134,4 +134,78 @@ def DXSA_UMin : DXSA_BinaryOp<"umin"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// dxsa.imad
+//===----------------------------------------------------------------------===//
+
+def DXSA_Imad : DXSA_MultiplyAddOp<"imad"> {
+  let summary = "component-wise integer multiply-add";
+  let description = [{
+    The `dxsa.imad` operation computes the component-wise integer
+    multiply-add `$dst = $lhs * $rhs + $acc`. No carry or borrow beyond the
+    32-bit value of each component is performed, so the result is not
+    sensitive to the signedness of its operands.
+
+    Example:
+
+    ```mlir
+    dxsa.imad r<0>, r<1>, r<2>, r<3>
+    dxsa.imad r<0>, -r<1>, r<2>, r<3>
+    dxsa.imad r<0, <x>>, r<1, <y>>, r<2, <x>>, r<3, <z>>
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.imul
+//===----------------------------------------------------------------------===//
+
+def DXSA_Imul : DXSA_Op<"imul"> {
+  let summary = "component-wise integer multiply";
+  let description = [{
+    The `dxsa.imul` operation computes the component-wise product
+    `$lhs * $rhs` as a 64-bit integer and writes the high 32 bits to
+    `$dstHi` and the low 32 bits to `$dstLo`. Either destination may be
+    `null` when that half of the result is not needed.
+
+    Example:
+
+    ```mlir
+    dxsa.imul r<0>, r<1>, r<2>, r<3>
+    dxsa.imul null, r<0, <z>>, r<0, <y>>, -r<0, <x>>
+    dxsa.imul r<7, <x, y, z>>, r<3, <x, y, z>>, r<3, <x, y, z, x>>, r<4, <x, y, z, x>>
+    ```
+  }];
+  let arguments = (ins
+      DXSA_DstOperandAttr:$dstHi,
+      DXSA_DstOperandAttr:$dstLo,
+      DXSA_SrcOperandAttr:$lhs,
+      DXSA_SrcOperandAttr:$rhs,
+      OptionalAttr<DXSA_ComponentMaskAttr>:$precise);
+  let results = (outs);
+  let assemblyFormat =
+      "(`precise` $precise^)? $dstHi `,` $dstLo `,` $lhs `,` $rhs attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.msad
+//===----------------------------------------------------------------------===//
+
+def DXSA_Msad : DXSA_TernaryOp<"msad"> {
+  let summary = "component-wise masked sum of absolute differences";
+  let description = [{
+    The `dxsa.msad` operation computes the component-wise masked sum of
+    absolute differences. For each 32-bit component, `$src0` and `$src1`
+    each hold four packed 8-bit unsigned integers, and `$src2` supplies a
+    32-bit unsigned accumulation value. The result is written to `$dst`.
+
+    Example:
+
+    ```mlir
+    dxsa.msad r<0>, r<0>, r<1>, r<2>
+    dxsa.msad r<1, <x>>, r<1, <x>>, r<1, <y>>, r<1, <z>>
+    ```
+  }];
+}
+
 #endif // MLIR_DIALECT_DXSA_IR_DXSAINTARITHOPS

--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSAOpBase.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSAOpBase.td
@@ -61,4 +61,17 @@ class DXSA_TernaryOp<string mnemonic> : DXSA_Op<mnemonic> {
       "(`precise` $precise^)? $dst `,` $src0 `,` $src1 `,` $src2 attr-dict";
 }
 
+// Shared base for the multiply-add family: `$dst = $lhs * $rhs + $acc`.
+class DXSA_MultiplyAddOp<string mnemonic> : DXSA_Op<mnemonic> {
+  let arguments = (ins
+      DXSA_DstOperandAttr:$dst,
+      DXSA_SrcOperandAttr:$lhs,
+      DXSA_SrcOperandAttr:$rhs,
+      DXSA_SrcOperandAttr:$acc,
+      OptionalAttr<DXSA_ComponentMaskAttr>:$precise);
+  let results = (outs);
+  let assemblyFormat =
+      "(`precise` $precise^)? $dst `,` $lhs `,` $rhs `,` $acc attr-dict";
+}
+
 #endif // MLIR_DIALECT_DXSA_IR_DXSAOPBASE

--- a/mlir/lib/Target/DXSA/BinaryParser.cpp
+++ b/mlir/lib/Target/DXSA/BinaryParser.cpp
@@ -2405,6 +2405,12 @@ public:
       return PLAIN_OP(UMax, 1, 2, HasPreciseAttr::Yes);
     case D3D10_SB_OPCODE_UMIN:
       return PLAIN_OP(UMin, 1, 2, HasPreciseAttr::Yes);
+    case D3D10_SB_OPCODE_IMAD:
+      return PLAIN_OP(Imad, 1, 3, HasPreciseAttr::Yes);
+    case D3D10_SB_OPCODE_IMUL:
+      return PLAIN_OP(Imul, 2, 2, HasPreciseAttr::Yes);
+    case D3D11_1_SB_OPCODE_MSAD:
+      return PLAIN_OP(Msad, 1, 3, HasPreciseAttr::Yes);
     // Bitwise instructions
     case D3D10_SB_OPCODE_AND:
       return PLAIN_OP(And, 1, 2, HasPreciseAttr::Yes);

--- a/mlir/test/Target/DXSA/int_arith_ops.test
+++ b/mlir/test/Target/DXSA/int_arith_ops.test
@@ -103,3 +103,109 @@
 // CHECK-NEXT:   dxsa.umin r<0, <x>>, r<1, <y, z, w, y>>, r<2, <x, x, x, x>>
 // CHECK-NEXT: }
 0x07000054, 0x00100012, 0x00000000, 0x00100796, 0x00000001, 0x00100006, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.imad precise <x, y, z, w> r<0>, r<0>, r<1>, r<2>
+// CHECK-NEXT:  }
+0x09780023, 0x001000F2, 0x00000000, 0x00100E46, 0x00000000, 0x00100E46, 0x00000001, 0x00100E46, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.imad r<1>, r<1>, r<2>, r<3>
+// CHECK-NEXT:  }
+0x09000023, 0x001000F2, 0x00000001, 0x00100E46, 0x00000001, 0x00100E46, 0x00000002, 0x00100E46, 0x00000003
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.imad r<1>, -r<1>, r<2>, r<3>
+// CHECK-NEXT:  }
+0x0A000023, 0x001000F2, 0x00000001, 0x80100E46, 0x00000041, 0x00000001, 0x00100E46, 0x00000002, 0x00100E46, 0x00000003
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.imad r<1>, -r<1>, r<2>, -r<3>
+// CHECK-NEXT:  }
+0x0B000023, 0x001000F2, 0x00000001, 0x80100E46, 0x00000041, 0x00000001, 0x00100E46, 0x00000002, 0x80100E46, 0x00000041, 0x00000003
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.imad r<1>, r<1, <y, x, z, w>>, r<2>, r<3, <z, x, y, w>>
+// CHECK-NEXT:  }
+0x09000023, 0x001000F2, 0x00000001, 0x00100E16, 0x00000001, 0x00100E46, 0x00000002, 0x00100D26, 0x00000003
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.imad r<1, <x>>, r<1, <x>>, r<1, <y>>, r<1, <z>>
+// CHECK-NEXT:  }
+0x09000023, 0x00100012, 0x00000001, 0x0010000A, 0x00000001, 0x0010001A, 0x00000001, 0x0010002A, 0x00000001
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.imul precise <x, y, z> r<7, <x, y, z>>, r<3, <x, y, z>>, r<3, <x, y, z, x>>, r<4, <x, y, z, x>>
+// CHECK-NEXT:  }
+0x09380026, 0x00100072, 0x00000007, 0x00100072, 0x00000003, 0x00100246, 0x00000003, 0x00100246, 0x00000004
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.imul r<6, <x, z, w>>, r<2, <x, z, w>>, r<2, <y, y, z, x>>, r<3, <y, y, z, x>>
+// CHECK-NEXT:  }
+0x09000026, 0x001000d2, 0x00000006, 0x001000d2, 0x00000002, 0x00100256, 0x00000002, 0x00100256, 0x00000003
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.imul r<5, <x>>, r<1, <x>>, r<1, <y>>, r<1, <x>>
+// CHECK-NEXT:  }
+0x09000026, 0x00100012, 0x00000005, 0x00100012, 0x00000001, 0x0010001a, 0x00000001, 0x0010000a, 0x00000001
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.imul r<5, <w>>, r<0, <w>>, -r<1, <y>>, r<1, <x>>
+// CHECK-NEXT:  }
+0x0a000026, 0x00100082, 0x00000005, 0x00100082, 0x00000000, 0x8010001a, 0x00000041, 0x00000001, 0x0010000a, 0x00000001
+
+// -----
+
+// Typically, FXC produces imul with null for destHI operand.
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.imul null, r<0, <z>>, r<0, <y>>, -r<0, <x>>
+// CHECK-NEXT:  }
+0x09000026, 0x0000d000, 0x00100042, 0x00000000, 0x0010001a, 0x00000000, 0x8010000a, 0x00000041, 0x00000000
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.msad r<0>, r<0>, r<1>, r<2>
+// CHECK-NEXT: }
+0x090000D5, 0x001000F2, 0x00000000, 0x001000F2, 0x00000000, 0x001000F2, 0x00000001, 0x001000F2, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.msad r<1, <x, y>>, r<1, <x, x, x, x>>, r<2, <y, z, y, y>>, r<1, <y, z, y, y>>
+// CHECK-NEXT: }
+0x090000D5, 0x00100032, 0x00000001, 0x00100006, 0x00000001, 0x00100596, 0x00000002, 0x00100596, 0x00000001
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.msad precise <x, y, z, w> r<2>, r<2, <x, x, x, x>>, r<4>, r<3, <z, w, x, y>>
+// CHECK-NEXT: }
+0x097800D5, 0x001000F2, 0x00000002, 0x00100006, 0x00000002, 0x00100E46, 0x00000004, 0x001004E6, 0x00000003
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:    dxsa.msad r<1, <x>>, r<1, <x>>, r<1, <y>>, r<1, <z>>
+// CHECK-NEXT: }
+0x090000D5, 0x00100012, 0x00000001, 0x0010000A, 0x00000001, 0x0010001A, 0x00000001, 0x0010002A, 0x00000001


### PR DESCRIPTION
Examples:
```
dxsa.imad r<1>, r<1>, r<2>, r<3>
dxsa.imul r<5, <w>>, r<0, <w>>, -r<1, <y>>, r<1, <x>>
dxsa.msad r<0>, r<0>, r<1>, r<2>
```