### PR TITLE
[dxsa][mlir] Add bufinfo, resinfo, samplepos, sampleinfo

### DIFF
--- a/mlir/include/mlir/Dialect/DXSA/IR/DXSAResourceOps.td
+++ b/mlir/include/mlir/Dialect/DXSA/IR/DXSAResourceOps.td
@@ -16,6 +16,201 @@
 include "mlir/Dialect/DXSA/IR/DXSAOpBase.td"
 
 //===----------------------------------------------------------------------===//
+// dxsa.bufinfo
+//===----------------------------------------------------------------------===//
+
+def DXSA_BufInfo : DXSA_UnaryOp<"bufinfo"> {
+  let summary = "query the element count on a Buffer (but not Constant Buffer)";
+  let description = [{
+    srcResource (`$src`) can be a Buffer (not a Constant Buffer) in an
+    SRV (`t#`) or UAV (`u#`).
+
+    All components in `$dst` receive the integer number of elements in the
+    Buffer’s Shader Resource View. The number of elements depends on the
+    view parameters such as memory format.
+
+    For a Typed Buffer SRV or UAV, the return value is the number of elements
+    in the View (where an element is one unit of the typed format).
+
+    For a Raw Buffer SRV or UAV, the return value is the number of bytes in
+    the view.
+
+    For a Structured Buffer SRV or UAV, the return value is the number of
+    structures in the view.
+
+    Example:
+
+    ```mlir
+    dxsa.bufinfo r<0, <x>>, t<0, vector>
+    dxsa.bufinfo r<0, <y>>, u<1, vector, <y, x, z, w>>
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.resinfo
+//===----------------------------------------------------------------------===//
+
+def DXSA_ResInfo : DXSA_BinaryOp<"resinfo"> {
+  let summary = "query the dimensions of a given input resource.";
+  let description = [{
+    The `dxsa.resinfo` queries the dimensions of a given input resource.
+
+    srcMipLevel (`$lhs`) is read as an unsigned integer scalar
+    (so a single component selector is required for the
+    source register, if it is not a scalar immediate value).
+    srcResource (`$rhs`) is a `t#` or `u#` input texture for which the
+    dimensions are being queried.
+    `$dst` receives [width, height, depth or array size, total-mip-count],
+    selected by the write mask.
+
+    Returned values are all floating point, unless the `_uint` modifier is used,
+    in which case the returned values are all integers. If the `_rcpFloat`
+    modifier is used, all returned values are floating point, and the width,
+    height and depth are returned as reciprocals (1.0f/width, 1.0f/height,
+    1.0f/depth), including INF if width/height/depth are 0 (from out-of-range
+    srcMipLevel behavior above). Note that the `_rcpFloat` modifier only applies
+    to width, height, and depth returned values (and does not apply to values
+    that are set to 0 and thus not returned, and also does not apply to array
+    size returns).
+
+    For more information, see Direct3D 11.3 Functional Specification, 22.4.14.
+
+    Example:
+
+    ```mlir
+    dxsa.resinfo r<0>, r<1, <x>>, r<2>
+    dxsa.resinfo r<0, <x>>, r<1, <x>>, r<2, <x, x, x, x>>
+    ```
+  }];
+}
+
+def DXSA_ResInfoUInt : DXSA_BinaryOp<"resinfo_uint"> {
+  let summary = "query the dimensions of a given input resource.";
+  let description = [{
+    The `dxsa.resinfo_uint` queries the dimensions of a given input resource.
+    Returned values are all integer.
+
+    See `dxsa.resinfo` for more info.
+
+    Example:
+
+    ```mlir
+    dxsa.resinfo_uint r<0>, r<1, <x>>, r<2>
+    dxsa.resinfo_uint r<0, <x>>, r<1, <x>>, r<2, <x, x, x, x>>
+    ```
+  }];
+}
+
+def DXSA_ResInfoRcpFloat : DXSA_BinaryOp<"resinfo_rcpFloat"> {
+  let summary = "query the dimensions of a given input resource.";
+  let description = [{
+    The `dxsa.resinfo_rcpFloat` queries the dimensions of a given input resource.
+    All returned values are floating point, and the width, height and depth are
+    returned as reciprocals (1.0f/width, 1.0f/height, 1.0f/depth),
+    including INF if width/height/depth are 0 (from out-of-range srcMipLevel
+    behavior above).
+    Note that the `_rcpFloat` modifier only applies to width, height, and depth
+    returned values (and does not apply to values that are set to 0 and thus
+    not returned, and also does not apply to array size returns).
+
+    See `dxsa.resinfo` for more info.
+
+    Example:
+
+    ```mlir
+    dxsa.resinfo_rcpFloat r<0>, r<1, <x>>, r<2>
+    dxsa.resinfo_rcpFloat r<0, <x>>, r<1, <x>>, r<2, <x, x, x, x>>
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.sampleinfo
+//===----------------------------------------------------------------------===//
+
+def DXSA_SampleInfo : DXSA_UnaryOp<"sampleinfo"> {
+  let summary = "query the number of samples in a given shader resource view "
+                "or in the rasterizer";
+  let description = [{
+    The `dxsa.sampleinfo` returns the number of samples for the given resource
+    or the rasterizer. Only valid for resources that can be loaded using `ld2dms`
+    unless the "rasterizer" is specified as `$src`.
+    `$src` could be `t#` register (a shader resource view) or "rasterizer" register.
+
+    The instruction computes the following vector (SampleCount,0,0,0).
+    The swizzle on srcResource allows the returned values to be swizzled
+    arbitrarily before they are written to the destination.
+    If there is no resource bound to the specified slot, 0 is returned.
+    Returned value is floating point.
+
+    Example:
+
+    ```mlir
+    dxsa.sampleinfo r<0>, r<1>
+    dxsa.sampleinfo o<0, <x, y>>, rasterizer<vector, <x>>
+    ```
+  }];
+}
+
+def DXSA_SampleInfoUInt : DXSA_UnaryOp<"sampleinfo_uint"> {
+  let summary = "query the number of samples in a given shader resource view "
+                "or in the rasterizer";
+  let description = [{
+    The `dxsa.sampleinfo_uint` returns the number of samples for the given resource
+    or the rasterizer. Only valid for resources that can be loaded using `ld2dms`
+    unless the "rasterizer" is specified as `$src`.
+    `$src` could be `t#` register (a shader resource view) or "rasterizer" register.
+
+    The instruction computes the following vector (SampleCount,0,0,0).
+    The swizzle on srcResource allows the returned values to be swizzled
+    arbitrarily before they are written to the destination.
+    If there is no resource bound to the specified slot, 0 is returned.
+    Returned value is integer.
+
+    Example:
+
+    ```mlir
+    dxsa.sampleinfo_uint r<0>, r<1>
+    dxsa.sampleinfo_uint o<0, <x, y>>, rasterizer<vector, <x>>
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dxsa.samplepos
+//===----------------------------------------------------------------------===//
+
+def DXSA_SamplePos : DXSA_BinaryOp<"samplepos"> {
+  let summary = "query the position of a sample in a given shader resource "
+                "view or in the rasterizer.";
+  let description = [{
+    The `dxsa.samplepos` returns the 2D sample position of sample
+    sampleIndex (`$rhs`) for the given resource. Only valid for resources that
+    can be loaded using `ld2dms` unless the "rasterizer" is specified as
+    srcResource (`$lhs`).
+
+    srcResource could be t# register (a shader resource view) or "rasterizer" register.
+
+    The instruction computes the following floating point vector (Xposition, Yposition, 0, 0).
+
+    The swizzle on srcResource allows the returned values to be swizzled arbitrarily
+    before they are written to the destination.
+    The sample position is relative to the pixel's center, based on the Pixel Coordinate System (3.3.1).
+
+    If sampleIndex is out of bounds a zero vector is returned.
+    If there is no resource bound to the specified slot, 0 is returned.
+
+    Example:
+
+    ```mlir
+    dxsa.samplepos r<0>, r<1>, l(0x2)
+    dxsa.samplepos r<0>, r<1>, r<2, <x, x, x, x>>
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // dxsa.eval_centroid
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Target/DXSA/BinaryParser.cpp
+++ b/mlir/lib/Target/DXSA/BinaryParser.cpp
@@ -3423,6 +3423,7 @@ public:
       case D3D10_SB_RESINFO_INSTRUCTION_RETURN_UINT:
         return PLAIN_OP(ResInfoUInt, 1, 2, HasPreciseAttr::Yes);
       }
+      llvm_unreachable("unhandled resinfo");
     }
     case D3D10_1_SB_OPCODE_SAMPLE_INFO: {
       D3D10_SB_INSTRUCTION_RETURN_TYPE sampleinfo_type =
@@ -3433,6 +3434,7 @@ public:
       case D3D10_SB_INSTRUCTION_RETURN_UINT:
         return PLAIN_OP(SampleInfoUInt, 1, 1, HasPreciseAttr::Yes);
       }
+      llvm_unreachable("unhandled sampleinfo");
     }
     case D3D10_1_SB_OPCODE_SAMPLE_POS:
       return PLAIN_OP(SamplePos, 1, 2, HasPreciseAttr::Yes);
@@ -3694,11 +3696,15 @@ public:
   }
 
   LogicalResult verifyInstructionLength(size_t beginOffset, uint32_t length) {
+    // WORKAROUND: some instructions such as samplepos have trailing
+    // tokens that do not correspond to any operands. Therefore we
+    // allow actual instruction length to be less then length read
+    // from the opcode token.
     if (((currentTokenOffset - beginOffset) / tokenSize) > length) {
       emitError(getLocation(), "operands did not fit into instruction length");
       return failure();
     }
-    // Skip unparsed tokens in the end
+    // WORKAROUND: skip unparsed tokens in the end. See above.
     while (((currentTokenOffset - beginOffset) / tokenSize) < length) {
       auto token = parseToken();
       FAILURE_IF_FAILED(token);

--- a/mlir/lib/Target/DXSA/BinaryParser.cpp
+++ b/mlir/lib/Target/DXSA/BinaryParser.cpp
@@ -3410,6 +3410,32 @@ public:
     case D3D11_SB_OPCODE_EMITTHENCUT_STREAM:
       return STREAM_INDEX_OP(EmitThenCutStream);
     // Resource instructions
+    case D3D11_SB_OPCODE_BUFINFO:
+      return PLAIN_OP(BufInfo, 1, 1, HasPreciseAttr::Yes);
+    case D3D10_SB_OPCODE_RESINFO: {
+      D3D10_SB_RESINFO_INSTRUCTION_RETURN_TYPE resinfo_type =
+          DECODE_D3D10_SB_RESINFO_INSTRUCTION_RETURN_TYPE(*opcodeToken0);
+      switch (resinfo_type) {
+      case D3D10_SB_RESINFO_INSTRUCTION_RETURN_FLOAT:
+        return PLAIN_OP(ResInfo, 1, 2, HasPreciseAttr::Yes);
+      case D3D10_SB_RESINFO_INSTRUCTION_RETURN_RCPFLOAT:
+        return PLAIN_OP(ResInfoRcpFloat, 1, 2, HasPreciseAttr::Yes);
+      case D3D10_SB_RESINFO_INSTRUCTION_RETURN_UINT:
+        return PLAIN_OP(ResInfoUInt, 1, 2, HasPreciseAttr::Yes);
+      }
+    }
+    case D3D10_1_SB_OPCODE_SAMPLE_INFO: {
+      D3D10_SB_INSTRUCTION_RETURN_TYPE sampleinfo_type =
+          DECODE_D3D10_SB_INSTRUCTION_RETURN_TYPE(*opcodeToken0);
+      switch (sampleinfo_type) {
+      case D3D10_SB_INSTRUCTION_RETURN_FLOAT:
+        return PLAIN_OP(SampleInfo, 1, 1, HasPreciseAttr::Yes);
+      case D3D10_SB_INSTRUCTION_RETURN_UINT:
+        return PLAIN_OP(SampleInfoUInt, 1, 1, HasPreciseAttr::Yes);
+      }
+    }
+    case D3D10_1_SB_OPCODE_SAMPLE_POS:
+      return PLAIN_OP(SamplePos, 1, 2, HasPreciseAttr::Yes);
     case D3D11_SB_OPCODE_EVAL_CENTROID:
       return PLAIN_OP(EvalCentroid, 1, 1, HasPreciseAttr::Yes);
     case D3D11_SB_OPCODE_EVAL_SAMPLE_INDEX:
@@ -3668,9 +3694,14 @@ public:
   }
 
   LogicalResult verifyInstructionLength(size_t beginOffset, uint32_t length) {
-    if (((currentTokenOffset - beginOffset) / tokenSize) != length) {
-      emitError(getLocation(), "instruction length mismatch");
+    if (((currentTokenOffset - beginOffset) / tokenSize) > length) {
+      emitError(getLocation(), "operands did not fit into instruction length");
       return failure();
+    }
+    // Skip unparsed tokens in the end
+    while (((currentTokenOffset - beginOffset) / tokenSize) < length) {
+      auto token = parseToken();
+      FAILURE_IF_FAILED(token);
     }
     return success();
   }

--- a/mlir/test/Target/DXSA/hlsl/bufinfo.test
+++ b/mlir/test/Target/DXSA/hlsl/bufinfo.test
@@ -11,42 +11,18 @@
 // CHECK:         dxsa.dcl_uav_typed <id = 3, dim =  buffer>, <x =  sint, y =  sint, z =  sint, w =  sint>
 // CHECK:         dxsa.dcl_output o<0, <x>>
 // CHECK:         dxsa.dcl_temps 1
-// CHECK:         %[[INDEX_0:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_0:.*]] = dxsa.operand %[[INDEX_0]] {mask = 16 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_1:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_1:.*]] = dxsa.operand %[[INDEX_1]] {num_components = 4 : i32, swizzle = dense<[0, 1, 2, 3]> : vector<4xi32>, type = 7 : i32}
-// CHECK:         dxsa.instruction "bufinfo" %[[OPERAND_0]], %[[OPERAND_1]]
+// CHECK:         dxsa.bufinfo r<0, <x>>, t<0, vector>
 // CHECK:         dxsa.iadd r<0, <x>>, r<0, <x>>, l(0x34)
-// CHECK:         %[[INDEX_2:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_2:.*]] = dxsa.operand %[[INDEX_2]] {mask = 32 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_3:.*]] = dxsa.index.imm {imm = 1 : i32}
-// CHECK:         %[[OPERAND_3:.*]] = dxsa.operand %[[INDEX_3]] {num_components = 4 : i32, swizzle = dense<[1, 0, 2, 3]> : vector<4xi32>, type = 30 : i32}
-// CHECK:         dxsa.instruction "bufinfo" %[[OPERAND_2]], %[[OPERAND_3]]
+// CHECK:         dxsa.bufinfo r<0, <y>>, u<1, vector, <y, x, z, w>>
 // CHECK:         dxsa.iadd r<0, <x>>, r<0, <x>>, r<0, <y>>
 // CHECK:         dxsa.iadd r<0, <x>>, r<0, <x>>, l(0x34)
-// CHECK:         %[[INDEX_4:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_4:.*]] = dxsa.operand %[[INDEX_4]] {mask = 32 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_5:.*]] = dxsa.index.imm {imm = 1 : i32}
-// CHECK:         %[[OPERAND_5:.*]] = dxsa.operand %[[INDEX_5]] {num_components = 4 : i32, swizzle = dense<[1, 0, 2, 3]> : vector<4xi32>, type = 7 : i32}
-// CHECK:         dxsa.instruction "bufinfo" %[[OPERAND_4]], %[[OPERAND_5]]
+// CHECK:         dxsa.bufinfo r<0, <y>>, t<1, vector, <y, x, z, w>>
 // CHECK:         dxsa.iadd r<0, <x>>, r<0, <y>>, r<0, <x>>
-// CHECK:         %[[INDEX_6:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_6:.*]] = dxsa.operand %[[INDEX_6]] {mask = 32 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_7:.*]] = dxsa.index.imm {imm = 2 : i32}
-// CHECK:         %[[OPERAND_7:.*]] = dxsa.operand %[[INDEX_7]] {num_components = 4 : i32, swizzle = dense<[1, 0, 2, 3]> : vector<4xi32>, type = 30 : i32}
-// CHECK:         dxsa.instruction "bufinfo" %[[OPERAND_6]], %[[OPERAND_7]]
+// CHECK:         dxsa.bufinfo r<0, <y>>, u<2, vector, <y, x, z, w>>
 // CHECK:         dxsa.iadd r<0, <x>>, r<0, <y>>, r<0, <x>>
-// CHECK:         %[[INDEX_8:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_8:.*]] = dxsa.operand %[[INDEX_8]] {mask = 32 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_9:.*]] = dxsa.index.imm {imm = 2 : i32}
-// CHECK:         %[[OPERAND_9:.*]] = dxsa.operand %[[INDEX_9]] {num_components = 4 : i32, swizzle = dense<[1, 0, 2, 3]> : vector<4xi32>, type = 7 : i32}
-// CHECK:         dxsa.instruction "bufinfo" %[[OPERAND_8]], %[[OPERAND_9]]
+// CHECK:         dxsa.bufinfo r<0, <y>>, t<2, vector, <y, x, z, w>>
 // CHECK:         dxsa.iadd r<0, <x>>, r<0, <y>>, r<0, <x>>
-// CHECK:         %[[INDEX_10:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_10:.*]] = dxsa.operand %[[INDEX_10]] {mask = 32 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_11:.*]] = dxsa.index.imm {imm = 3 : i32}
-// CHECK:         %[[OPERAND_11:.*]] = dxsa.operand %[[INDEX_11]] {num_components = 4 : i32, swizzle = dense<[1, 0, 2, 3]> : vector<4xi32>, type = 30 : i32}
-// CHECK:         dxsa.instruction "bufinfo" %[[OPERAND_10]], %[[OPERAND_11]]
+// CHECK:         dxsa.bufinfo r<0, <y>>, u<3, vector, <y, x, z, w>>
 // CHECK:         dxsa.iadd o<0, <x>>, r<0, <y>>, r<0, <x>>
 // CHECK:         dxsa.ret
 

--- a/mlir/test/Target/DXSA/hlsl/getdim.test
+++ b/mlir/test/Target/DXSA/hlsl/getdim.test
@@ -12,77 +12,40 @@
 // CHECK:         dxsa.dcl_output o<0>
 // CHECK:         dxsa.dcl_temps 2
 // CHECK:         dxsa.ftou r<0, <x>>, v<0, <w>>
-// CHECK:         %[[INDEX_0:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_0:.*]] = dxsa.operand %[[INDEX_0]] {mask = 224 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_1:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_1:.*]] = dxsa.operand %[[INDEX_1]] {num_components = 4 : i32, one = 0 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_2:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_2:.*]] = dxsa.operand %[[INDEX_2]] {num_components = 4 : i32, swizzle = dense<[2, 0, 1, 3]> : vector<4xi32>, type = 7 : i32}
-// CHECK:         dxsa.instruction "resinfo" %[[OPERAND_0]], %[[OPERAND_1]], %[[OPERAND_2]]
+// CHECK:         dxsa.resinfo_uint r<0, <y, z, w>>, r<0, <x>>, t<0, vector, <z, x, y, w>>
 // CHECK:         dxsa.iadd r<0, <y>>, r<0, <y>>, r<0, <x>>
 // CHECK:         dxsa.iadd r<0, <y>>, r<0, <z>>, r<0, <y>>
 // CHECK:         dxsa.iadd r<0, <y>>, r<0, <w>>, r<0, <y>>
-// CHECK:         %[[INDEX_3:.*]] = dxsa.index.imm {imm = 1 : i32}
-// CHECK:         %[[OPERAND_3:.*]] = dxsa.operand %[[INDEX_3]] {mask = 48 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[OPERAND_4:.*]] = dxsa.operand.imm {imm = dense<0> : vector<1xi32>}
-// CHECK:         %[[INDEX_4:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_5:.*]] = dxsa.operand %[[INDEX_4]] {num_components = 4 : i32, swizzle = dense<[0, 1, 2, 3]> : vector<4xi32>, type = 7 : i32}
-// CHECK:         dxsa.instruction "resinfo" %[[OPERAND_3]], %[[OPERAND_4]], %[[OPERAND_5]]
+// CHECK:         dxsa.resinfo_uint r<1, <x, y>>, l(0x0), t<0, vector>
 // CHECK:         dxsa.iadd r<0, <z>>, r<0, <x>>, r<1, <x>>
 // CHECK:         dxsa.iadd r<0, <z>>, r<1, <y>>, r<0, <z>>
 // CHECK:         dxsa.iadd r<0, <z>>, r<0, <w>>, r<0, <z>>
 // CHECK:         dxsa.utof r<0, <y, z>>, r<0, <y, y, z, y>>
 // CHECK:         dxsa.add r<0, <y>>, r<0, <z>>, r<0, <y>>
-// CHECK:         %[[INDEX_5:.*]] = dxsa.index.imm {imm = 1 : i32}
-// CHECK:         %[[OPERAND_6:.*]] = dxsa.operand %[[INDEX_5]] {mask = 240 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_6:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_7:.*]] = dxsa.operand %[[INDEX_6]] {num_components = 4 : i32, one = 0 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_7:.*]] = dxsa.index.imm {imm = 1 : i32}
-// CHECK:         %[[OPERAND_8:.*]] = dxsa.operand %[[INDEX_7]] {num_components = 4 : i32, swizzle = dense<[0, 1, 2, 3]> : vector<4xi32>, type = 7 : i32}
-// CHECK:         dxsa.instruction "resinfo" %[[OPERAND_6]], %[[OPERAND_7]], %[[OPERAND_8]]
+// CHECK:         dxsa.resinfo_uint r<1>, r<0, <x>>, t<1, vector>
 // CHECK:         dxsa.iadd r<0, <z>>, r<0, <x>>, r<1, <x>>
 // CHECK:         dxsa.iadd r<0, <z>>, r<1, <y>>, r<0, <z>>
 // CHECK:         dxsa.iadd r<0, <z>>, r<1, <z>>, r<0, <z>>
 // CHECK:         dxsa.iadd r<0, <z>>, r<1, <w>>, r<0, <z>>
 // CHECK:         dxsa.utof r<0, <z>>, r<0, <z>>
 // CHECK:         dxsa.add r<0, <y>>, r<0, <z>>, r<0, <y>>
-// CHECK:         %[[INDEX_8:.*]] = dxsa.index.imm {imm = 1 : i32}
-// CHECK:         %[[OPERAND_9:.*]] = dxsa.operand %[[INDEX_8]] {mask = 240 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_9:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_10:.*]] = dxsa.operand %[[INDEX_9]] {num_components = 4 : i32, one = 0 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_10:.*]] = dxsa.index.imm {imm = 2 : i32}
-// CHECK:         %[[OPERAND_11:.*]] = dxsa.operand %[[INDEX_10]] {num_components = 4 : i32, swizzle = dense<[0, 1, 2, 3]> : vector<4xi32>, type = 7 : i32}
-// CHECK:         dxsa.instruction "resinfo" %[[OPERAND_9]], %[[OPERAND_10]], %[[OPERAND_11]]
+// CHECK:         dxsa.resinfo_uint r<1>, r<0, <x>>, t<2, vector>
 // CHECK:         dxsa.iadd r<0, <z>>, r<0, <x>>, r<1, <x>>
 // CHECK:         dxsa.iadd r<0, <z>>, r<1, <y>>, r<0, <z>>
 // CHECK:         dxsa.iadd r<0, <z>>, r<1, <z>>, r<0, <z>>
 // CHECK:         dxsa.iadd r<0, <z>>, r<1, <w>>, r<0, <z>>
 // CHECK:         dxsa.utof r<0, <z>>, r<0, <z>>
 // CHECK:         dxsa.add r<0, <y>>, r<0, <z>>, r<0, <y>>
-// CHECK:         %[[INDEX_11:.*]] = dxsa.index.imm {imm = 1 : i32}
-// CHECK:         %[[OPERAND_12:.*]] = dxsa.operand %[[INDEX_11]] {mask = 112 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[OPERAND_13:.*]] = dxsa.operand.imm {imm = dense<0> : vector<1xi32>}
-// CHECK:         %[[INDEX_12:.*]] = dxsa.index.imm {imm = 3 : i32}
-// CHECK:         %[[OPERAND_14:.*]] = dxsa.operand %[[INDEX_12]] {num_components = 4 : i32, swizzle = dense<[0, 1, 2, 3]> : vector<4xi32>, type = 7 : i32}
-// CHECK:         dxsa.instruction "resinfo" %[[OPERAND_12]], %[[OPERAND_13]], %[[OPERAND_14]]
+// CHECK:         dxsa.resinfo_uint r<1, <x, y, z>>, l(0x0), t<3, vector>
 // CHECK:         dxsa.iadd r<0, <z>>, r<0, <x>>, r<1, <x>>
 // CHECK:         dxsa.iadd r<0, <z>>, r<1, <y>>, r<0, <z>>
 // CHECK:         dxsa.iadd r<0, <z>>, r<1, <z>>, r<0, <z>>
 // CHECK:         dxsa.iadd r<0, <z>>, r<1, <w>>, r<0, <z>>
-// CHECK:         %[[INDEX_13:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_15:.*]] = dxsa.operand %[[INDEX_13]] {mask = 128 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[INDEX_14:.*]] = dxsa.index.imm {imm = 3 : i32}
-// CHECK:         %[[OPERAND_16:.*]] = dxsa.operand %[[INDEX_14]] {num_components = 4 : i32, one = 0 : i32, type = 7 : i32}
-// CHECK:         dxsa.instruction "sampleinfo" %[[OPERAND_15]], %[[OPERAND_16]]
+// CHECK:         dxsa.sampleinfo_uint r<0, <w>>, t<3, vector, <x>>
 // CHECK:         dxsa.iadd r<0, <z>>, r<0, <w>>, r<0, <z>>
 // CHECK:         dxsa.utof r<0, <z>>, r<0, <z>>
 // CHECK:         dxsa.add r<0, <y>>, r<0, <z>>, r<0, <y>>
-// CHECK:         %[[INDEX_15:.*]] = dxsa.index.imm {imm = 1 : i32}
-// CHECK:         %[[OPERAND_17:.*]] = dxsa.operand %[[INDEX_15]] {mask = 48 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[OPERAND_18:.*]] = dxsa.operand.imm {imm = dense<0> : vector<1xi32>}
-// CHECK:         %[[INDEX_16:.*]] = dxsa.index.imm {imm = 1 : i32}
-// CHECK:         %[[OPERAND_19:.*]] = dxsa.operand %[[INDEX_16]] {num_components = 4 : i32, swizzle = dense<[0, 1, 2, 3]> : vector<4xi32>, type = 30 : i32}
-// CHECK:         dxsa.instruction "resinfo" %[[OPERAND_17]], %[[OPERAND_18]], %[[OPERAND_19]]
+// CHECK:         dxsa.resinfo_uint r<1, <x, y>>, l(0x0), u<1, vector>
 // CHECK:         dxsa.iadd r<0, <x>>, r<0, <x>>, r<1, <x>>
 // CHECK:         dxsa.iadd r<0, <x>>, r<1, <y>>, r<0, <x>>
 // CHECK:         dxsa.iadd r<0, <x>>, r<1, <z>>, r<0, <x>>

--- a/mlir/test/Target/DXSA/hlsl/interface1.test
+++ b/mlir/test/Target/DXSA/hlsl/interface1.test
@@ -4,15 +4,16 @@
 
 // CHECK-LABEL:   dxsa.dcl_global_flags <refactoringAllowed>
 // CHECK:         dxsa.dcl_constant_buffer <id = 0, size = 1>, <immediateIndexed>
-// CHECK:         dxsa.unknown <tokens = [0x02000090, 0x00000000]>
-// CHECK:         dxsa.unknown <tokens = [0x02000090, 0x00000001]>
-// CHECK:         dxsa.unknown <tokens = [0x04000091, 0x00000000, 0x00000001, 0x00000000]>
-// CHECK:         dxsa.unknown <tokens = [0x04000091, 0x00000001, 0x00000001, 0x00000001]>
-// CHECK:         dxsa.unknown <tokens = [0x06000892, 0x00000000, 0x00000001, 0x00FD0002, 0x00000000, 0x00000001]>
+// CHECK:         dxsa.instruction "dcl_function_body"
+// CHECK:         dxsa.instruction "dcl_function_body"
+// CHECK:         dxsa.instruction "dcl_function_table"
+// CHECK:         dxsa.instruction "dcl_function_table"
+// CHECK:         dxsa.instruction "dcl_interface"
 // CHECK:         dxsa.dcl_output o<0, <x>>
 // CHECK:         dxsa.dcl_temps 2
 // CHECK:         dxsa.mov r<0, <x>>, cb<[0, 0], vector, <x>>
-// CHECK:         dxsa.unknown <tokens = [0x06000078, 0x00000000, 0x04213000, 0x00000000, 0x0010000A, 0x00000000]>
+// CHECK:         %0 = dxsa.operand  {num_components = 0 : i32, type = 0 : i32}
+// CHECK:         dxsa.instruction "fcall" %0
 // CHECK:         dxsa.mov o<0, <x>>, r<0, <y>>
 // CHECK:         dxsa.ret
 // CHECK:         dxsa.label fb<0>

--- a/mlir/test/Target/DXSA/hlsl/samplecount.test
+++ b/mlir/test/Target/DXSA/hlsl/samplecount.test
@@ -4,10 +4,7 @@
 
 // CHECK-LABEL:   dxsa.dcl_global_flags <refactoringAllowed>
 // CHECK:         dxsa.dcl_output o<0>
-// CHECK:         %[[INDEX_0:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_0:.*]] = dxsa.operand %[[INDEX_0]] {mask = 48 : i32, num_components = 4 : i32, type = 2 : i32}
-// CHECK:         %[[OPERAND_1:.*]] = dxsa.operand  {num_components = 4 : i32, one = 0 : i32, type = 14 : i32}
-// CHECK:         dxsa.instruction "sampleinfo" %[[OPERAND_0]], %[[OPERAND_1]]
+// CHECK:         dxsa.sampleinfo o<0, <x, y>>, rasterizer<vector, <x>>
 // CHECK:         dxsa.mov o<0, <z, w>>, l(0x0, 0x0, 0x0, 0x0)
 // CHECK:         dxsa.ret
 

--- a/mlir/test/Target/DXSA/hlsl/samplepos.test
+++ b/mlir/test/Target/DXSA/hlsl/samplepos.test
@@ -10,20 +10,11 @@
 // CHECK:         dxsa.dcl_output o<1>
 // CHECK:         dxsa.dcl_temps 2
 // CHECK:         dxsa.ftoi r<0, <x, y, z>>, v<0, <z, w, y, z>>
-// CHECK:         dxsa.unknown <tokens = [0x0800006E, 0x00100092, 0x00000000, 0x00107406, 0x00000000, 0x0010000A, 0x00000000, 0x00000000]>
-// CHECK:         dxsa.unknown <tokens = [0x0800006E, 0x00100032, 0x00000001, 0x00107046, 0x00000001, 0x0010001A, 0x00000000, 0x00000000]>
-// CHECK:         %[[INDEX_0:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_0:.*]] = dxsa.operand %[[INDEX_0]] {mask = 96 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[OPERAND_1:.*]] = dxsa.operand  {num_components = 4 : i32, swizzle = dense<[0, 0, 1, 0]> : vector<4xi32>, type = 14 : i32}
-// CHECK:         %[[INDEX_1:.*]] = dxsa.index.imm {imm = 0 : i32}
-// CHECK:         %[[OPERAND_2:.*]] = dxsa.operand %[[INDEX_1]] {num_components = 4 : i32, one = 2 : i32, type = 0 : i32}
-// CHECK:         dxsa.instruction "samplepos" %[[OPERAND_0]], %[[OPERAND_1]], %[[OPERAND_2]]
+// CHECK:         dxsa.samplepos r<0, <x, w>>, t<0, vector, <x, x, x, y>>, r<0, <x>>
+// CHECK:         dxsa.samplepos r<1, <x, y>>, t<1, vector, <x, y, x, x>>, r<0, <y>>
+// CHECK:         dxsa.samplepos r<0, <y, z>>, rasterizer<vector, <x, x, y, x>>, r<0, <z>>
 // CHECK:         dxsa.add r<0, <x, w>>, r<0, <x, x, x, w>>, r<1, <x, x, x, y>>
-// CHECK:         %[[INDEX_2:.*]] = dxsa.index.imm {imm = 1 : i32}
-// CHECK:         %[[OPERAND_3:.*]] = dxsa.operand %[[INDEX_2]] {mask = 48 : i32, num_components = 4 : i32, type = 0 : i32}
-// CHECK:         %[[OPERAND_4:.*]] = dxsa.operand  {num_components = 4 : i32, swizzle = dense<[0, 1, 0, 0]> : vector<4xi32>, type = 14 : i32}
-// CHECK:         %[[OPERAND_5:.*]] = dxsa.operand.imm {imm = dense<3> : vector<1xi32>}
-// CHECK:         dxsa.instruction "samplepos" %[[OPERAND_3]], %[[OPERAND_4]], %[[OPERAND_5]]
+// CHECK:         dxsa.samplepos r<1, <x, y>>, rasterizer<vector, <x, y, x, x>>, l(0x3)
 // CHECK:         dxsa.add r<0, <x, w>>, r<0, <x, x, x, w>>, r<1, <x, x, x, y>>
 // CHECK:         dxsa.add r<0, <x, y>>, r<0, <y, z, y, y>>, r<0, <x, w, x, x>>
 // CHECK:         dxsa.mov o<0, <x, y>>, r<0, <x, y, x, x>>

--- a/mlir/test/Target/DXSA/resource_ops.test
+++ b/mlir/test/Target/DXSA/resource_ops.test
@@ -2,6 +2,174 @@
 // RUN: mlir-translate --split-input-file --import-dxsa-hex %s | mlir-opt --split-input-file --verify-roundtrip
 
 // CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.bufinfo r<0, <x>>, t<0, vector>
+// CHECK-NEXT: }
+0x87000079, 0x8001a302, 0x00199983, 0x00100012, 0x00000000, 0x00107e46, 0x00000000
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.bufinfo r<0, <y>>, u<1, vector, <y, x, z, w>>
+// CHECK-NEXT: }
+0x87000079, 0x8001a302, 0x00199983, 0x00100022, 0x00000000, 0x0011ee16, 0x00000001
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.bufinfo r<0, <y>>, t<1, vector, <y, x, z, w>>
+// CHECK-NEXT: }
+0x87000079, 0x800002c2, 0x00199983, 0x00100022, 0x00000000, 0x00107e16, 0x00000001
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.bufinfo r<0, <y>>, u<2, vector, <y, x, z, w>>
+// CHECK-NEXT: }
+0x87000079, 0x800002c2, 0x00199983, 0x00100022, 0x00000000, 0x0011ee16, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.bufinfo r<0, <y>>, t<2, vector, <y, x, z, w>>
+// CHECK-NEXT: }
+0x87000079, 0x80000042, 0x00044443, 0x00100022, 0x00000000, 0x00107e16, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.bufinfo r<0, <y>>, u<3, vector, <y, x, z, w>>
+// CHECK-NEXT: }
+0x87000079, 0x80000042, 0x000cccc3, 0x00100022, 0x00000000, 0x0011ee16, 0x00000003
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.resinfo r<0>, r<1, <x>>, r<2>
+// CHECK-NEXT: }
+0x0700003d, 0x001000f2, 0x00000000, 0x0010000a, 0x00000001, 0x00100e46, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.resinfo r<0, <x>>, r<1, <x>>, r<2, <x, x, x, x>>
+// CHECK-NEXT: }
+0x0700003d, 0x00100012, 0x00000000, 0x0010000a, 0x00000001, 0x00100006, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.resinfo_rcpFloat r<0>, r<1, <x>>, r<2>
+// CHECK-NEXT: }
+0x0700083d, 0x001000f2, 0x00000000, 0x0010000a, 0x00000001, 0x00100e46, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.resinfo_rcpFloat r<0, <x>>, r<1, <x>>, r<2, <x, x, x, x>>
+// CHECK-NEXT: }
+0x0700083d, 0x00100012, 0x00000000, 0x0010000a, 0x00000001, 0x00100006, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.resinfo_uint r<0, <y, z, w>>, r<0, <x>>, t<0, vector, <z, x, y, w>>
+// CHECK-NEXT: }
+0x8900103d, 0x800000c2, 0x00155543, 0x001000e2, 0x00000000, 0x0010000a, 0x00000000, 0x00107d26, 0x00000000
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.resinfo_uint r<1, <x, y>>, l(0x0), t<0, vector>
+// CHECK-NEXT: }
+0x8900103d, 0x800000c2, 0x00155543, 0x00100032, 0x00000001, 0x00004001, 0x00000000, 0x00107e46, 0x00000000
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.resinfo_uint r<1>, r<0, <x>>, t<1, vector>
+// CHECK-NEXT: }
+0x8900103d, 0x80000202, 0x00155543, 0x001000f2, 0x00000001, 0x0010000a, 0x00000000, 0x00107e46, 0x00000001
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.resinfo_uint r<1>, r<0, <x>>, t<2, vector>
+// CHECK-NEXT: }
+0x8900103d, 0x80000282, 0x00155543, 0x001000f2, 0x00000001, 0x0010000a, 0x00000000, 0x00107e46, 0x00000002
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.resinfo_uint r<1, <x, y, z>>, l(0x0), t<3, vector>
+// CHECK-NEXT: }
+0x8900103d, 0x80000242, 0x00155543, 0x00100072, 0x00000001, 0x00004001, 0x00000000, 0x00107e46, 0x00000003
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.resinfo_uint r<1, <x, y>>, l(0x0), u<1, vector>
+// CHECK-NEXT: }
+0x8900103d, 0x800000c2, 0x00155543, 0x00100032, 0x00000001, 0x00004001, 0x00000000, 0x0011ee46, 0x00000001
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.sampleinfo o<0, <x, y>>, rasterizer<vector, <x>>
+// CHECK-NEXT: }
+0x0400006f, 0x00102032, 0x00000000, 0x0000e00a
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.sampleinfo r<0>, r<1>
+// CHECK-NEXT: }
+0x0500006f, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.sampleinfo_uint o<0, <x, y>>, rasterizer<vector, <x>>
+// CHECK-NEXT: }
+0x0400086f, 0x00102032, 0x00000000, 0x0000e00a
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.sampleinfo_uint r<0>, r<1>
+// CHECK-NEXT: }
+0x0500086f, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.samplepos r<0, <x, w>>, t<0, vector, <x, x, x, y>>, r<0, <x>>
+// CHECK-NEXT: }
+0x0800006e, 0x00100092, 0x00000000, 0x00107406, 0x00000000, 0x0010000a, 0x00000000, 0x00000000
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.samplepos r<1, <x, y>>, t<1, vector, <x, y, x, x>>, r<0, <y>>
+// CHECK-NEXT: }
+0x0800006e, 0x00100032, 0x00000001, 0x00107046, 0x00000001, 0x0010001a, 0x00000000, 0x00000000
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.samplepos r<0, <y, z>>, rasterizer<vector, <x, x, y, x>>, r<0, <z>>
+// CHECK-NEXT: }
+0x0600006e, 0x00100062, 0x00000000, 0x0000e106, 0x0010002a, 0x00000000
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
+// CHECK-NEXT:   dxsa.samplepos r<1, <x, y>>, rasterizer<vector, <x, y, x, x>>, l(0x3)
+// CHECK-NEXT: }
+0x0600006e, 0x00100032, 0x00000001, 0x0000e046, 0x00004001, 0x00000003
+
+// -----
+
+// CHECK-LABEL: dxsa.module {
 // CHECK-NEXT:   dxsa.eval_centroid r<0>, r<1>
 // CHECK-NEXT: }
 0x050000cd, 0x001000f2, 0x00000000, 0x00100e46, 0x00000001

--- a/mlir/test/Target/DXSA/unknown.test
+++ b/mlir/test/Target/DXSA/unknown.test
@@ -24,12 +24,20 @@
 0x02000068, 0x00000003
 
 // Valid D3D10_SB_OPCODE_DCL_TEMPS opcode, but the length is 3 instead of 2.
-// CHECK-NEXT:   dxsa.unknown <tokens = [0x03000068, 0x00000005, 0xCAFEBABE]>
-// DIAG: warning: treating next 3 token(s) as unknown: instruction length mismatch
-0x03000068, 0x00000005, 0xCAFEBABE
-
+// This is allowed, the last one will be skipped.
 // CHECK-NEXT:   dxsa.dcl_temps 4
-0x02000068, 0x00000004
+0x03000068, 0x00000004, 0xCAFEBABE
+
+// CHECK-NEXT:   dxsa.dcl_temps 5
+0x02000068, 0x00000005
+
+// Valid D3D10_SB_OPCODE_DCL_TEMPS opcode, but the length is 1 instead of 2.
+// CHECK-NEXT:   dxsa.unknown <tokens = [0x01000068]>
+// CHECK-NEXT:   dxsa.unknown <tokens = [0x00000006]>
+0x01000068, 0x00000006
+
+// CHECK-NEXT:   dxsa.dcl_temps 7
+0x02000068, 0x00000007
 
 // add r0.xyzw, <src0>, r2.xyzw with the src0 operand type field corrupted to
 // an unknown value (0xFF).
@@ -37,7 +45,7 @@
 // DIAG: warning: treating next 7 token(s) as unknown: unknown operand type: 255
 0x07000000, 0x001000F2, 0x00000000, 0x001FFE46, 0x00000001, 0x00100E46, 0x00000002
 
-// CHECK-NEXT:   dxsa.dcl_temps 5
-0x02000068, 0x00000005
+// CHECK-NEXT:   dxsa.dcl_temps 8
+0x02000068, 0x00000008
 
 // CHECK-NEXT: }


### PR DESCRIPTION
Add resource instructions `bufinfo`, `resinfo`, `samplepos`, `sampleinfo`.

This patch also changes `verifyInstructionLength` so that it fails only if parsed operands length is greater than the specified instruction length in the opcode, and it skips the unparsed tokens if the specified instruction length is longer than parsed operands. This matches the behavior of `dxbc2dxil`, which doesn't check if there are unparsed tokens left, and simply moves further to parse tokens past the specified instruction length. `FXC` can output `samplepos` with an extra token in the end, not sure about other instructions.